### PR TITLE
Remove SER currency support

### DIFF
--- a/src/components/FxManager.test.tsx
+++ b/src/components/FxManager.test.tsx
@@ -1,0 +1,37 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FxManager } from './FxManager';
+import { saveRates, DEFAULT_RATES } from '../lib/fx';
+
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() { return Object.keys(store).length; }
+  } as Storage;
+};
+
+describe('FxManager', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock());
+    saveRates(DEFAULT_RATES);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('only shows supported currencies', () => {
+    render(<FxManager onClose={() => {}} />);
+
+    expect(screen.getByText('USD per USD')).toBeInTheDocument();
+    expect(screen.queryByText('SER per USD')).toBeNull();
+  });
+});

--- a/src/components/FxManager.tsx
+++ b/src/components/FxManager.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { loadRates, saveRates, applyPegs, refreshRates, hostProvider, type Cur, type Rates } from '../lib/fx';
 
-const CURS: Cur[] = ['USD','EGP','AED','SAR','SER','EUR'];
+const CURS: Cur[] = ['USD','EGP','AED','SAR','EUR'];
 
 export function FxManager({ onClose }:{ current?: Cur; onClose:()=>void }){
   const [rates, setRates] = useState<Rates>(loadRates());

--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -75,15 +75,9 @@ export default function MediaPlannerCard(p: Props){
             <option value="EGP">EGP</option>
             <option value="USD">USD</option>
             <option value="AED">AED</option>
-            <option value="SER">SER</option>
             <option value="SAR">SAR</option>
             <option value="EUR">EUR</option>
           </select>
-          {p.currency === 'SER' && (
-            <div className="mp-hint" style={{color:'#F5B971'}}>
-              Using SER→SAR unless FX set
-            </div>
-          )}
         </div>
 
         <div className="mp-field mp-col-6">

--- a/src/lib/assumptions.ts
+++ b/src/lib/assumptions.ts
@@ -9,7 +9,7 @@ export type Platform =
 
 export type Goal = 'LEADS' | 'TRAFFIC' | 'AWARENESS';
 export type Market = 'Egypt' | 'Saudi Arabia' | 'UAE' | 'Europe';
-export type Currency = 'EGP' | 'USD' | 'AED' | 'SAR' | 'SER' | 'EUR';
+export type Currency = 'EGP' | 'USD' | 'AED' | 'SAR' | 'EUR';
 
 export interface ChannelAssumptions {
   CPM?: number;

--- a/src/lib/fx.test.ts
+++ b/src/lib/fx.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_RATES, refreshRates, saveRates, loadRates, type Rates } from './fx';
+
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() { return Object.keys(store).length; }
+  } as Storage;
+};
+
+describe('refreshRates', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('merges live SAR rates while retaining existing values', async () => {
+    const seeded: Rates = { ...DEFAULT_RATES, EGP: 50, SAR: 3.6 };
+    saveRates(seeded);
+
+    const provider = vi.fn().mockResolvedValue({ SAR: 3.71 });
+    const merged = await refreshRates(provider, 0); // ttl=0 -> always refresh
+
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(merged.SAR).toBe(3.71);
+    expect(merged.EGP).toBe(50);
+
+    const persisted = loadRates();
+    expect(persisted.SAR).toBe(3.71);
+    expect(persisted.EGP).toBe(50);
+  });
+});

--- a/src/lib/fx.ts
+++ b/src/lib/fx.ts
@@ -1,19 +1,15 @@
 // src/lib/fx.ts
-export type Cur = 'USD'|'EGP'|'AED'|'SAR'|'SER'|'EUR';
+export type Cur = 'USD'|'EGP'|'AED'|'SAR'|'EUR';
 export type Rates = Record<Cur, number | null>;
 
 const KEY = 'mpl_fx_usd_per_v2';       // units per 1 USD
 const KEY_TS = 'mpl_fx_usd_per_ts_v2'; // cache timestamp (ms)
-
-// SER isn't an ISO code. Treat as SAR unless explicitly set.
-export const alias = (c: Cur): Cur => (c === 'SER' ? 'SAR' : c);
 
 // Default: pegs where sensible, null where you should decide.
 export const DEFAULT_RATES: Rates = {
   USD: 1,
   AED: 3.6725,        // market peg
   SAR: 3.75,          // market peg
-  SER: null,          // set if you really mean a different currency; alias->SAR in calc
   EGP: null,          // you set
   EUR: null,          // you set/fetch
 };
@@ -33,11 +29,11 @@ export function applyPegs(current: Rates): Rates {
 
 // --- Converters (math runs in USD) ---
 export function toUSD(amount: number, cur: Cur, r = loadRates()): number {
-  const code = alias(cur); const rate = r[code];
+  const rate = r[cur];
   return rate ? amount / rate : amount; // if missing, treat as already-USD
 }
 export function fromUSD(usd: number, cur: Cur, r = loadRates()): number {
-  const code = alias(cur); const rate = r[code];
+  const rate = r[cur];
   return rate ? usd * rate : usd;
 }
 
@@ -73,6 +69,5 @@ export async function refreshRates(provider: LiveFxProvider, ttlMs = 6*60*60*100
 
 // Simple guard: do we have a rate defined for the selected currency?
 export function hasRate(cur: Cur, usd_per = loadRates()): boolean {
-  const code = alias(cur);
-  return !!usd_per[code];
+  return !!usd_per[cur];
 }


### PR DESCRIPTION
## Summary
- remove the non-standard SER currency from shared currency types and rate handling
- update the FX manager UI and currency picker to only expose supported currencies and live rates
- add tests covering SAR rate merges and ensuring FxManager no longer lists SER

## Testing
- npm test
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eba5c3e48320832c11c6b6cef456