### PR TITLE
Handle zero total weight normalization in calculatePlatformWeights

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -42,6 +42,22 @@ describe('Media Plan Calculations', () => {
     expect(Math.abs(total - 1)).toBeLessThan(0.001);
   });
 
+  it('should distribute equally when calculated weights sum to zero', () => {
+    const platforms: Platform[] = ['YOUTUBE'];
+    const weights = calculatePlatformWeights(
+      platforms,
+      'LEADS',
+      false,
+      undefined,
+      false
+    );
+
+    expect(weights.YOUTUBE).toBe(1);
+
+    const total = Object.values(weights).reduce((sum, w) => sum + w, 0);
+    expect(Math.abs(total - 1)).toBeLessThan(0.001);
+  });
+
   // Test 3: Manual % split honors user inputs and normalizes
   it('should normalize manual percentage splits that do not sum to 100', () => {
     const platforms: Platform[] = ['FACEBOOK', 'GOOGLE_SEARCH'];
@@ -62,6 +78,27 @@ describe('Media Plan Calculations', () => {
     expect(weights.GOOGLE_SEARCH).toBeCloseTo(50 / 80, 5);
     
     const total = weights.FACEBOOK + weights.GOOGLE_SEARCH;
+    expect(Math.abs(total - 1)).toBeLessThan(0.001);
+  });
+
+  it('should distribute manual weights equally when total is non-positive', () => {
+    const platforms: Platform[] = ['FACEBOOK', 'INSTAGRAM'];
+    const manualWeights = {
+      FACEBOOK: 0,
+      INSTAGRAM: 0
+    } as Record<Platform, number>;
+
+    const weights = calculatePlatformWeights(
+      platforms,
+      'LEADS',
+      true,
+      manualWeights
+    );
+
+    expect(weights.FACEBOOK).toBeCloseTo(0.5, 5);
+    expect(weights.INSTAGRAM).toBeCloseTo(0.5, 5);
+
+    const total = Object.values(weights).reduce((sum, w) => sum + w, 0);
     expect(Math.abs(total - 1)).toBeLessThan(0.001);
   });
 

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -46,11 +46,26 @@ export function calculatePlatformWeights(
     // Normalize manual weights to sum to 100%
     const total = Object.values(manualWeights).reduce((sum, w) => sum + w, 0);
     const normalized: Record<Platform, number> = {} as any;
-    
+
+    if (total <= 0) {
+      const platformCount = selectedPlatforms.length;
+
+      if (platformCount === 0) {
+        return normalized;
+      }
+
+      const equalWeight = 1 / platformCount;
+      for (const platform of selectedPlatforms) {
+        normalized[platform] = equalWeight;
+      }
+
+      return normalized;
+    }
+
     for (const platform of selectedPlatforms) {
       normalized[platform] = (manualWeights[platform] || 0) / total;
     }
-    
+
     return normalized;
   }
 
@@ -74,10 +89,23 @@ export function calculatePlatformWeights(
 
   // Normalize to sum to 1
   const total = Object.values(weights).reduce((sum, w) => sum + w, 0);
-  if (total > 0) {
-    for (const platform of selectedPlatforms) {
-      weights[platform] = weights[platform] / total;
+  if (total <= 0) {
+    const platformCount = selectedPlatforms.length;
+
+    if (platformCount === 0) {
+      return weights;
     }
+
+    const equalWeight = 1 / platformCount;
+    for (const platform of selectedPlatforms) {
+      weights[platform] = equalWeight;
+    }
+
+    return weights;
+  }
+
+  for (const platform of selectedPlatforms) {
+    weights[platform] = weights[platform] / total;
   }
 
   return weights;


### PR DESCRIPTION
## Summary
- handle non-positive totals in calculatePlatformWeights by evenly distributing weights across selected platforms
- extend unit tests to cover fallback weight distribution for automatic and manual splits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ebaa43a083208f619ff3bb6f71aa