### PR TITLE
Clarify fractional weight normalization messaging

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -43,7 +43,7 @@ describe('Media Plan Calculations', () => {
   });
 
   // Test 3: Manual % split honors user inputs and normalizes
-  it('should normalize manual percentage splits that do not sum to 100', () => {
+  it('should normalize manual splits to fractional weights even if inputs total less than 100', () => {
     const platforms: Platform[] = ['FACEBOOK', 'GOOGLE_SEARCH'];
     const manualWeights = {
       FACEBOOK: 30,
@@ -57,7 +57,7 @@ describe('Media Plan Calculations', () => {
       manualWeights as any
     );
 
-    // Should normalize 80% total to 100%
+    // Should convert 80 total input points into fractional weights summing to 1
     expect(weights.FACEBOOK).toBeCloseTo(30 / 80, 5);
     expect(weights.GOOGLE_SEARCH).toBeCloseTo(50 / 80, 5);
     

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -43,7 +43,7 @@ export function calculatePlatformWeights(
   includeAll: boolean = false
 ): Record<Platform, number> {
   if (manualSplit && manualWeights) {
-    // Normalize manual weights to sum to 100%
+    // Normalize manual weights to fractional values summing to 1 (100%)
     const total = Object.values(manualWeights).reduce((sum, w) => sum + w, 0);
     const normalized: Record<Platform, number> = {} as any;
     
@@ -72,7 +72,7 @@ export function calculatePlatformWeights(
     }
   }
 
-  // Normalize to sum to 1
+  // Normalize to fractional weights summing to 1
   const total = Object.values(weights).reduce((sum, w) => sum + w, 0);
   if (total > 0) {
     for (const platform of selectedPlatforms) {


### PR DESCRIPTION
## Summary
- clarify math utilities comments to explain that normalized weights are fractional values summing to 1 (100%)
- align the manual weight normalization test description and comment with the fractional wording

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ebaaf94c8320a5e78b797185fe7e