### PR TITLE
Handle zero-sum manual weights and add regression test

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -91,6 +91,33 @@ describe('Media Plan Calculations', () => {
     expect(total).toBeCloseTo(1, 5);
   });
 
+  it('should ignore weights for deselected platforms when normalizing manual split', () => {
+    const platforms: Platform[] = ['FACEBOOK', 'GOOGLE_SEARCH'];
+    const manualWeights = {
+      FACEBOOK: 20,
+      GOOGLE_SEARCH: 30,
+      INSTAGRAM: 50
+    };
+
+    const weights = calculatePlatformWeights(
+      platforms,
+      'LEADS',
+      true,
+      manualWeights as any
+    );
+
+    const totalSelectedWeight = manualWeights.FACEBOOK + manualWeights.GOOGLE_SEARCH;
+
+    expect(weights.FACEBOOK).toBeCloseTo(manualWeights.FACEBOOK / totalSelectedWeight, 5);
+    expect(weights.GOOGLE_SEARCH).toBeCloseTo(
+      manualWeights.GOOGLE_SEARCH / totalSelectedWeight,
+      5
+    );
+
+    const total = platforms.reduce((sum, platform) => sum + weights[platform], 0);
+    expect(total).toBeCloseTo(1, 5);
+  });
+
   // Test 4: Views present for Facebook, Instagram, YouTube, TikTok, LinkedIn
   it('should calculate views for platforms with VTR', () => {
     const platforms: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];

--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -49,7 +49,7 @@ describe('Media Plan Calculations', () => {
       FACEBOOK: 30,
       GOOGLE_SEARCH: 50
     };
-    
+
     const weights = calculatePlatformWeights(
       platforms,
       'LEADS',
@@ -60,9 +60,35 @@ describe('Media Plan Calculations', () => {
     // Should normalize 80% total to 100%
     expect(weights.FACEBOOK).toBeCloseTo(30 / 80, 5);
     expect(weights.GOOGLE_SEARCH).toBeCloseTo(50 / 80, 5);
-    
+
     const total = weights.FACEBOOK + weights.GOOGLE_SEARCH;
     expect(Math.abs(total - 1)).toBeLessThan(0.001);
+  });
+
+  it('should fallback to equal split when manual weights sum to zero', () => {
+    const platforms: Platform[] = ['FACEBOOK', 'GOOGLE_SEARCH', 'INSTAGRAM'];
+    const manualWeights = {
+      FACEBOOK: 0,
+      GOOGLE_SEARCH: 0,
+      INSTAGRAM: 0
+    };
+
+    const weights = calculatePlatformWeights(
+      platforms,
+      'LEADS',
+      true,
+      manualWeights as any
+    );
+
+    const expectedWeight = 1 / platforms.length;
+
+    platforms.forEach(platform => {
+      expect(Number.isFinite(weights[platform])).toBe(true);
+      expect(weights[platform]).toBeCloseTo(expectedWeight, 5);
+    });
+
+    const total = platforms.reduce((sum, platform) => sum + weights[platform], 0);
+    expect(total).toBeCloseTo(1, 5);
   });
 
   // Test 4: Views present for Facebook, Instagram, YouTube, TikTok, LinkedIn

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -46,11 +46,19 @@ export function calculatePlatformWeights(
     // Normalize manual weights to sum to 100%
     const total = Object.values(manualWeights).reduce((sum, w) => sum + w, 0);
     const normalized: Record<Platform, number> = {} as any;
-    
-    for (const platform of selectedPlatforms) {
-      normalized[platform] = (manualWeights[platform] || 0) / total;
+
+    if (total > 0) {
+      for (const platform of selectedPlatforms) {
+        normalized[platform] = (manualWeights[platform] || 0) / total;
+      }
+    } else {
+      const equalWeight =
+        selectedPlatforms.length > 0 ? 1 / selectedPlatforms.length : 0;
+      for (const platform of selectedPlatforms) {
+        normalized[platform] = equalWeight;
+      }
     }
-    
+
     return normalized;
   }
 

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -44,12 +44,16 @@ export function calculatePlatformWeights(
 ): Record<Platform, number> {
   if (manualSplit && manualWeights) {
     // Normalize manual weights to sum to 100%
-    const total = Object.values(manualWeights).reduce((sum, w) => sum + w, 0);
+    const total = selectedPlatforms.reduce(
+      (sum, platform) => sum + (manualWeights[platform] ?? 0),
+      0
+    );
     const normalized: Record<Platform, number> = {} as any;
 
     if (total > 0) {
       for (const platform of selectedPlatforms) {
-        normalized[platform] = (manualWeights[platform] || 0) / total;
+        const weight = manualWeights[platform] ?? 0;
+        normalized[platform] = weight / total;
       }
     } else {
       const equalWeight =


### PR DESCRIPTION
## Summary
- fallback to an equal split when manual weight inputs sum to zero so manual planning remains usable
- add a regression test covering the zero-sum manual weight scenario and asserting finite outputs

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8ebaf2ee88320bc330f413ca56f81