### PR TITLE
Add CPL overrides and FX controls

### DIFF
--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -159,7 +159,9 @@ export default function MediaPlannerCard(p: Props){
       {/* Split Controls Row */}
       <SplitControlsRow
         mode={p.mode}
+        includeAll={p.includeAll}
         onChangeMode={p.onModeChange}
+        onIncludeAllChange={p.onIncludeAllChange}
       />
     </section>
   );

--- a/src/components/SplitControlsRow.tsx
+++ b/src/components/SplitControlsRow.tsx
@@ -2,7 +2,9 @@
 
 type Props = {
   mode: "auto" | "manual";
+  includeAll: boolean;
   onChangeMode: (m: "auto" | "manual") => void;
+  onIncludeAllChange: (value: boolean) => void;
 };
 
 const chip = {
@@ -13,8 +15,12 @@ const chip = {
 
 export default function SplitControlsRow({
   mode,
+  includeAll,
   onChangeMode,
+  onIncludeAllChange,
 }: Props) {
+  const toggleDisabled = mode !== "auto";
+
   return (
     <div style={{ ...chip.surface, borderRadius: 16, padding: 12 }} data-testid="split-controls-row">
       <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
@@ -40,37 +46,71 @@ export default function SplitControlsRow({
         {/* removed Platforms count pill */}
 
         {/* Segmented control */}
-        <div style={{ marginLeft: "auto", ...chip.inner, border: "1px solid #27292B", borderRadius: 12, padding: 4 }}>
-          <button
-            onClick={() => onChangeMode("auto")}
-            style={{
-              padding: "6px 14px",
-              fontSize: 14,
-              borderRadius: 8,
-              background: mode === "auto" ? "#2C2C2C" : "transparent",
-              color: mode === "auto" ? "#FFFFFF" : "#BDBDBD",
-              transition: "background .15s ease, color .15s ease",
-              border: "none",
-              cursor: "pointer",
-            }}
-          >
-            Auto
-          </button>
-          <button
-            onClick={() => onChangeMode("manual")}
-            style={{
-              padding: "6px 14px",
-              fontSize: 14,
-              borderRadius: 8,
-              background: mode === "manual" ? "#2C2C2C" : "transparent",
-              color: mode === "manual" ? "#FFFFFF" : "#BDBDBD",
-              transition: "background .15s ease, color .15s ease",
-              border: "none",
-              cursor: "pointer",
-            }}
-          >
-            Manual
-          </button>
+        <div
+          style={{
+            marginLeft: "auto",
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+            justifyContent: "flex-end",
+          }}
+        >
+          <div style={{ ...chip.inner, border: "1px solid #27292B", borderRadius: 12, padding: 4, display: "flex" }}>
+            <button
+              onClick={() => onChangeMode("auto")}
+              style={{
+                padding: "6px 14px",
+                fontSize: 14,
+                borderRadius: 8,
+                background: mode === "auto" ? "#2C2C2C" : "transparent",
+                color: mode === "auto" ? "#FFFFFF" : "#BDBDBD",
+                transition: "background .15s ease, color .15s ease",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Auto
+            </button>
+            <button
+              onClick={() => onChangeMode("manual")}
+              style={{
+                padding: "6px 14px",
+                fontSize: 14,
+                borderRadius: 8,
+                background: mode === "manual" ? "#2C2C2C" : "transparent",
+                color: mode === "manual" ? "#FFFFFF" : "#BDBDBD",
+                transition: "background .15s ease, color .15s ease",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Manual
+            </button>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <label
+              className="switch"
+              title="Give every selected platform at least 10% of the budget in auto mode"
+              aria-label="Give every selected platform at least 10% of the budget in auto mode"
+              style={{
+                opacity: toggleDisabled ? 0.4 : 1,
+                pointerEvents: toggleDisabled ? "none" : "auto",
+                cursor: toggleDisabled ? "not-allowed" : "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={includeAll}
+                onChange={(e) => onIncludeAllChange(e.target.checked)}
+                disabled={toggleDisabled}
+              />
+              <span className="slider" />
+            </label>
+            <span style={{ fontSize: 13, color: "#BDBDBD" }}>
+              Min 10% each{toggleDisabled ? ' (auto only)' : ''}
+            </span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- surface manual CPL overrides by wiring the cost override card into the planner flow
- expose the auto-split helper with a toggle that enforces a 10% floor per selected platform
- add a persistent Manage FX button in the header for quick access to currency settings

## Testing
- npm run build
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9015fbc108320bfc06e76b3ffcda3