### PR TITLE
Handle FX refresh failures

### DIFF
--- a/src/lib/fx.test.ts
+++ b/src/lib/fx.test.ts
@@ -57,7 +57,7 @@ describe('refreshRates', () => {
     expect(result).toEqual(seeded);
   });
 
-  it('returns existing rates when the provider rejects', async () => {
+  it('bubbles the provider error while leaving existing rates untouched', async () => {
     const seeded: Rates = { ...DEFAULT_RATES, AED: 3.66 };
     saveRates(seeded);
 
@@ -67,10 +67,9 @@ describe('refreshRates', () => {
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
     const provider = vi.fn().mockRejectedValue(new Error('network down'));
-    const result = await refreshRates(provider, ttlMs);
+    await expect(refreshRates(provider, ttlMs)).rejects.toThrow('network down');
 
     expect(provider).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(seeded);
     expect(loadRates()).toEqual(seeded);
   });
 });

--- a/src/lib/fx.ts
+++ b/src/lib/fx.ts
@@ -61,9 +61,10 @@ export async function refreshRates(provider: LiveFxProvider, ttlMs = 6*60*60*100
     const merged: Rates = { ...current, ...live };
     saveRates(merged); saveTs(now);
     return merged;
-  } catch {
-    // keep current on failure
-    return current;
+  } catch (err) {
+    // keep current on failure but surface the error for callers
+    if (err instanceof Error) throw err;
+    throw new Error('Failed to refresh FX rates');
   }
 }
 


### PR DESCRIPTION
## Summary
- propagate `refreshRates` errors so the UI can signal when live FX fetching fails
- update the FX unit test to match the new error bubbling behaviour while ensuring cached rates remain unchanged

## Testing
- npm test --silent -- run


------
https://chatgpt.com/codex/tasks/task_b_68cafb34245083218465623c04a386bd