### PR TITLE
Fallback to equal manual split when selected weights sum to zero

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -102,6 +102,46 @@ describe('Media Plan Calculations', () => {
     expect(Math.abs(total - 1)).toBeLessThan(0.001);
   });
 
+  it('should fall back to an equal split when selected manual weights sum to zero', () => {
+    const platforms: Platform[] = ['FACEBOOK', 'INSTAGRAM'];
+    const manualWeights = {
+      FACEBOOK: 0,
+      INSTAGRAM: 0,
+      GOOGLE_SEARCH: 100
+    } as Record<Platform, number>;
+
+    const totalBudget = 8000;
+    const results = calculateResults({
+      totalBudget,
+      selectedPlatforms: platforms,
+      goal: 'LEADS',
+      market: 'Egypt',
+      leadToSalePercent: 20,
+      revenuePerSale: 800,
+      manualSplit: true,
+      platformWeights: manualWeights,
+      includeAll: false,
+      manualCPL: false
+    });
+
+    expect(results).toHaveLength(platforms.length);
+
+    results.forEach((result) => {
+      expect(result.weight).toBeGreaterThan(0);
+      expect(Number.isFinite(result.weight)).toBe(true);
+      expect(result.budget).toBeGreaterThan(0);
+      expect(Number.isFinite(result.budget)).toBe(true);
+      expect(Number.isFinite(result.impressions)).toBe(true);
+      expect(Number.isFinite(result.clicks)).toBe(true);
+    });
+
+    const allocated = results.reduce((sum, item) => sum + item.budget, 0);
+    expect(allocated).toBeCloseTo(totalBudget, 5);
+
+    const weightSum = results.reduce((sum, item) => sum + item.weight, 0);
+    expect(weightSum).toBeCloseTo(1, 5);
+  });
+
   // Test 4: Views present for Facebook, Instagram, YouTube, TikTok, LinkedIn
   it('should calculate views for platforms with VTR', () => {
     const platforms: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -44,7 +44,10 @@ export function calculatePlatformWeights(
 ): Record<Platform, number> {
   if (manualSplit && manualWeights) {
     // Normalize manual weights to fractional values summing to 1 (100%)
-    const total = Object.values(manualWeights).reduce((sum, w) => sum + w, 0);
+    const manualValues = selectedPlatforms.map(
+      (platform) => Math.max(0, manualWeights[platform] ?? 0)
+    );
+    const total = manualValues.reduce((sum, weight) => sum + weight, 0);
     const normalized: Record<Platform, number> = {} as any;
 
     if (total <= 0) {
@@ -62,9 +65,9 @@ export function calculatePlatformWeights(
       return normalized;
     }
 
-    for (const platform of selectedPlatforms) {
-      normalized[platform] = (manualWeights[platform] || 0) / total;
-    }
+    selectedPlatforms.forEach((platform, index) => {
+      normalized[platform] = manualValues[index] / total;
+    });
 
     return normalized;
   }


### PR DESCRIPTION
## Summary
- limit manual weight normalization to the selected platforms and fall back to an equal share when their manual inputs sum to zero
- add a regression test to ensure the zero-sum manual scenario yields finite, fully allocated results

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cafc72cb148321a421ba232fcdd7d5