### PR TITLE
Fix persisted state hydration for falsy values

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,19 +71,19 @@ function App() {
   useEffect(() => {
     const savedState = loadState();
     if (savedState) {
-      if (savedState.totalBudget) setTotalBudget(savedState.totalBudget);
-      if (savedState.currency) setCurrency(savedState.currency);
-      if (savedState.market) setMarket(savedState.market);
-      if (savedState.goal) setGoal(savedState.goal);
-      if (savedState.niche) setNiche(savedState.niche);
-      if (savedState.leadToSalePercent) setLeadToSalePercent(savedState.leadToSalePercent);
-      if (savedState.revenuePerSale) setRevenuePerSale(savedState.revenuePerSale);
-      if (savedState.selectedPlatforms) setSelectedPlatforms(savedState.selectedPlatforms);
+      if (savedState.totalBudget !== undefined) setTotalBudget(savedState.totalBudget);
+      if (savedState.currency !== undefined) setCurrency(savedState.currency);
+      if (savedState.market !== undefined) setMarket(savedState.market);
+      if (savedState.goal !== undefined) setGoal(savedState.goal);
+      if (savedState.niche !== undefined) setNiche(savedState.niche);
+      if (savedState.leadToSalePercent !== undefined) setLeadToSalePercent(savedState.leadToSalePercent);
+      if (savedState.revenuePerSale !== undefined) setRevenuePerSale(savedState.revenuePerSale);
+      if (savedState.selectedPlatforms !== undefined) setSelectedPlatforms(savedState.selectedPlatforms);
       if (savedState.manualSplit !== undefined) setManualSplit(savedState.manualSplit);
-      if (savedState.platformWeights) setPlatformWeights(savedState.platformWeights);
+      if (savedState.platformWeights !== undefined) setPlatformWeights(savedState.platformWeights);
       if (savedState.includeAll !== undefined) setIncludeAll(savedState.includeAll);
       if (savedState.manualCPL !== undefined) setManualCPL(savedState.manualCPL);
-      if (savedState.platformCPLs) setPlatformCPLs(savedState.platformCPLs);
+      if (savedState.platformCPLs !== undefined) setPlatformCPLs(savedState.platformCPLs);
     }
   }, []);
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -108,19 +108,16 @@ export function loadState(): Partial<AppState> | null {
         next.manualCPL = raw.manualCPL;
       }
 
-      const platforms = sanitizePlatformList(raw.selectedPlatforms as unknown);
-      if (platforms.length > 0) {
-        next.selectedPlatforms = platforms;
+      if ('selectedPlatforms' in raw) {
+        next.selectedPlatforms = sanitizePlatformList(raw.selectedPlatforms as unknown);
       }
 
-      const weights = sanitizeNumberRecord(raw.platformWeights);
-      if (Object.keys(weights).length > 0) {
-        next.platformWeights = weights;
+      if ('platformWeights' in raw) {
+        next.platformWeights = sanitizeNumberRecord(raw.platformWeights);
       }
 
-      const cpls = sanitizeNumberRecord(raw.platformCPLs);
-      if (Object.keys(cpls).length > 0) {
-        next.platformCPLs = cpls;
+      if ('platformCPLs' in raw) {
+        next.platformCPLs = sanitizeNumberRecord(raw.platformCPLs);
       }
 
       return next;


### PR DESCRIPTION
## Summary
- allow saved state hydration to restore falsy values such as 0 or empty strings in the main app state effect
- persist intentionally empty platform selections, weights, and CPL overrides when loading from storage

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68cb03cbba888321baa750428db836b4