### PR TITLE
Fix zero-valued metrics display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import ResultsByPlatformCard from './components/ResultsByPlatformCard';
 import ColumnsDialog from './components/ColumnsDialog';
 import type { ColumnDef } from './components/ColumnsDialog';
 import RecommendationsCard from './components/RecommendationsCard';
-import { fmt } from './utils/format';
+import { fmt, isFiniteNumber } from './utils/format';
 import { deriveDisplayWeights } from './utils/split';
 import { AllocationCard } from './components/AllocationCard';
 import { CostOverridesCard } from './components/CostOverridesCard';
@@ -259,8 +259,8 @@ function App() {
     clicks: fmt(r.clicks, 0),
     leads: fmt(r.leads, 0),
     cpl: fmt(r.cpl, 2),
-    views: r.views ? fmt(r.views, 0) : "—",
-    eng: r.engagements ? fmt(r.engagements, 0) : "—",
+    views: isFiniteNumber(r.views) ? fmt(r.views, 0) : "—",
+    eng: isFiniteNumber(r.engagements) ? fmt(r.engagements, 0) : "—",
     ctr: `${fmt(r.ctr * 100, 2)}%`,
     cpc: fmt(r.cpc, 2),
     cpm: fmt(r.cpm, 2),
@@ -273,12 +273,12 @@ function App() {
     clicks: fmt(totals.clicks, 0),
     leads: fmt(totals.leads, 0),
     cpl: fmt(totals.cpl, 2),
-    views: totals.views ? fmt(totals.views, 0) : "—",
-    eng: totals.engagements ? fmt(totals.engagements, 0) : "—",
+    views: isFiniteNumber(totals.views) ? fmt(totals.views, 0) : "—",
+    eng: isFiniteNumber(totals.engagements) ? fmt(totals.engagements, 0) : "—",
     ctr: "—",
     cpc: "—",
     cpm: "—",
-    roas: totals.roas ? `${fmt(totals.roas, 2)}x` : "—",
+    roas: isFiniteNumber(totals.roas) ? `${fmt(totals.roas, 2)}x` : "—",
   };
 
   // Charts data (Budget Split)

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { fmt } from '../utils/format';
+import { fmt, isFiniteNumber } from '../utils/format';
 import { ResultsHeader } from '../components/ResultsHeader';
 
 type Row = {
@@ -152,7 +152,7 @@ export function ResultsTable({
                     node = CPM != null ? fmt(CPM,2) : '—';
                   }
                   else if(c.key==='views' || c.key==='engagements' || c.key==='impressions' || c.key==='reach' || c.key==='clicks' || c.key==='leads'){
-                    node = (raw ?? 0) ? fmt(raw,0) : '—';
+                    node = isFiniteNumber(raw) ? fmt(raw,0) : '—';
                   }
                   else if(c.key==='name'){
                     node = <span className="tnum">{r.name}</span>;
@@ -175,8 +175,8 @@ export function ResultsTable({
                 else if(c.key==='clicks') v=fmt(totals.clicks||0,0);
                 else if(c.key==='leads') v=fmt(totals.leads||0,0);
                 else if(c.key==='CPL_eff') v=fmt(totals.CPL_total ?? 0,2);
-                else if(c.key==='views') v= totals.views ? fmt(totals.views,0) : '—';
-                else if(c.key==='engagements') v= totals.engagements ? fmt(totals.engagements,0) : '—';
+                else if(c.key==='views') v= isFiniteNumber(totals.views) ? fmt(totals.views,0) : '—';
+                else if(c.key==='engagements') v= isFiniteNumber(totals.engagements) ? fmt(totals.engagements,0) : '—';
                 return <td key={String(c.key)} className={(c.align??'right')==='left'?'text-left':'text-right'}>{v}</td>;
               })}
             </tr>

--- a/src/components/ResultsTablePro.tsx
+++ b/src/components/ResultsTablePro.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { fmt } from '../utils/format';
+import { fmt, isFiniteNumber } from '../utils/format';
 
 type Row = {
   platform?: string; name?: string;
@@ -16,8 +16,8 @@ const COLS = [
   { key: 'clicks', label: 'Clicks', fmt: (v: number) => fmt(v, 0), align: 'right' as const },
   { key: 'leads', label: 'Leads', fmt: (v: number) => fmt(v, 0), align: 'right' as const },
   { key: 'cpl', label: 'CPL', fmt: (v: number) => fmt(v ?? 0, 2), align: 'right' as const },
-  { key: 'views', label: 'Views', fmt: (v: number) => (v ?? 0) ? fmt(v, 0) : '—', align: 'right' as const },
-  { key: 'engagements', label: 'Eng.', fmt: (v: number) => (v ?? 0) ? fmt(v, 0) : '—', align: 'right' as const },
+  { key: 'views', label: 'Views', fmt: (v: number) => (isFiniteNumber(v) ? fmt(v, 0) : '—'), align: 'right' as const },
+  { key: 'engagements', label: 'Eng.', fmt: (v: number) => (isFiniteNumber(v) ? fmt(v, 0) : '—'), align: 'right' as const },
   { key: 'ctr', label: 'CTR', fmt: (v: number) => fmt((v ?? 0) * 100, 2) + '%', align: 'right' as const },
   { key: 'cpc', label: 'CPC', fmt: (v: number) => fmt(v ?? 0, 2), align: 'right' as const },
   { key: 'cpm', label: 'CPM', fmt: (v: number) => fmt(v ?? 0, 2), align: 'right' as const },
@@ -80,8 +80,8 @@ export function ResultsTablePro({ rows, totals, currency }: { rows: Row[]; total
             <td className="tnum text-right">{fmt(totals.clicks || 0, 0)}</td>
             <td className="tnum text-right">{fmt(totals.leads || 0, 0)}</td>
             <td className="tnum text-right">{fmt((totals.CPL_total ?? totals.cpl ?? 0), 2)}</td>
-            <td className="tnum text-right">{totals.views ? fmt(totals.views, 0) : '—'}</td>
-            <td className="tnum text-right">{totals.engagements ? fmt(totals.engagements, 0) : '—'}</td>
+            <td className="tnum text-right">{isFiniteNumber(totals.views) ? fmt(totals.views, 0) : '—'}</td>
+            <td className="tnum text-right">{isFiniteNumber(totals.engagements) ? fmt(totals.engagements, 0) : '—'}</td>
             <td className="tnum text-right"></td>
             <td className="tnum text-right"></td>
             <td className="tnum text-right"></td>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,2 +1,5 @@
 export const fmt = (n: number, d = 0) =>
   new Intl.NumberFormat('en-US', { maximumFractionDigits: d, minimumFractionDigits: d }).format(n);
+
+export const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);


### PR DESCRIPTION
## Summary
- show zero-valued views and engagement metrics instead of the em dash placeholder
- keep aggregate ROAS values of 0 visible by checking for finite numbers before formatting
- add a reusable `isFiniteNumber` helper alongside the shared `fmt` utility

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68cb03e0b548832196bcb1ade67d25d9