### PR TITLE
Refactor App into modular hooks and components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,120 +1,68 @@
-import './styles/theme.css'
-import './styles/charts.css'
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import type { Platform, Goal, Market, Currency } from './lib/assumptions';
+import './styles/theme.css';
+import './styles/charts.css';
+import { useCallback, useMemo, useState } from 'react';
+import type { Platform } from './lib/assumptions';
 import { NICHE_DEFAULTS } from './lib/assumptions';
-import { calculateResults, calculateTotals } from './lib/math';
-import { generateRecommendations } from './lib/recommendations';
-// New export API
-import type { ExportPayload } from './export';
-import type { AppState } from './lib/storage';
-import { saveState, loadState } from './lib/storage';
-import { Download, Settings } from 'lucide-react';
-import { PLATFORM_LABELS, formatNumber, formatCurrency } from './lib/utils';
+import { PLATFORM_LABELS } from './lib/utils';
 import { BudgetDonutPro, ImpressionsBarsPro } from './components/ChartsPro';
 import ResultsByPlatformCard from './components/ResultsByPlatformCard';
 import ColumnsDialog from './components/ColumnsDialog';
 import type { ColumnDef } from './components/ColumnsDialog';
 import RecommendationsCard from './components/RecommendationsCard';
-import { fmt } from './utils/format';
-import { deriveDisplayWeights } from './utils/split';
 import { AllocationCard } from './components/AllocationCard';
 import { CostOverridesCard } from './components/CostOverridesCard';
 import { FxManager } from './components/FxManager';
-import { hasRate } from './lib/fx';
+import { hasRate, type Cur } from './lib/fx';
 import MediaPlannerCard from './components/MediaPlannerCard';
+import PlannerHeader from './components/PlannerHeader';
+import FxWarning from './components/FxWarning';
+import KpiCards from './components/KpiCards';
+import { usePlannerState } from './hooks/usePlannerState';
+import { usePlannerDerivedData } from './hooks/usePlannerDerivedData';
+import { useExportManager } from './hooks/useExportManager';
 
-const ALL_PLATFORMS: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'GOOGLE_SEARCH', 'GOOGLE_DISPLAY', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];
+const ALL_PLATFORMS: Platform[] = [
+  'FACEBOOK',
+  'INSTAGRAM',
+  'GOOGLE_SEARCH',
+  'GOOGLE_DISPLAY',
+  'YOUTUBE',
+  'TIKTOK',
+  'LINKEDIN',
+];
+
 const PLATFORM_NAME_MAP: Record<string, string> = Object.fromEntries(
   ALL_PLATFORMS.map((platform) => [platform, PLATFORM_LABELS[platform] || platform])
 );
 
-const sanitizeFilename = (name: string) => {
-  const cleaned = name.trim().replace(/[\\/:*?"<>|]/g, '-');
-  const normalized = cleaned.replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '');
-  return normalized;
-};
+const DEFAULT_COLUMNS: ColumnDef[] = [
+  { key: 'budget', label: 'Budget', visible: true },
+  { key: 'impr', label: 'Impr.', visible: true },
+  { key: 'reach', label: 'Reach', visible: true },
+  { key: 'clicks', label: 'Clicks', visible: true },
+  { key: 'leads', label: 'Leads', visible: true },
+  { key: 'cpl', label: 'CPL', visible: true },
+  { key: 'views', label: 'Views', visible: true },
+  { key: 'eng', label: 'Eng.', visible: true },
+  { key: 'ctr', label: 'CTR', visible: true },
+  { key: 'cpc', label: 'CPC', visible: true },
+  { key: 'cpm', label: 'CPM', visible: true },
+];
 
 function App() {
-  // State management (keeping all existing state)
-  const [totalBudget, setTotalBudget] = useState(10000);
-  const [currency, setCurrency] = useState<Currency>('USD');
-  const [market, setMarket] = useState<Market>('Egypt');
-  const [goal, setGoal] = useState<Goal>('LEADS');
-  const [niche, setNiche] = useState('Generic');
-  const [leadToSalePercent, setLeadToSalePercent] = useState(20);
-  const [revenuePerSale, setRevenuePerSale] = useState(800);
-  const [selectedPlatforms, setSelectedPlatforms] = useState<Platform[]>(['FACEBOOK', 'GOOGLE_SEARCH']);
-  const [manualSplit, setManualSplit] = useState(false);
-  const [platformWeights, setPlatformWeights] = useState<Record<Platform, number>>({} as any);
-  const [includeAll, setIncludeAll] = useState(false);
-  const [manualCPL, setManualCPL] = useState(false);
-  const [platformCPLs, setPlatformCPLs] = useState<Record<Platform, number>>({} as any);
-  const [mode, setMode] = useState<'auto'|'manual'>(manualSplit ? 'manual' : 'auto');
+  const planner = usePlannerState();
+  const derived = usePlannerDerivedData(planner);
+  const exportManager = useExportManager({
+    state: planner,
+    totals: derived.totals,
+    results: derived.results,
+  });
+
   const [showFx, setShowFx] = useState(false);
   const [columnsOpen, setColumnsOpen] = useState(false);
-  const [cols, setCols] = useState<ColumnDef[]>([
-    { key:"budget", label:"Budget", visible:true },
-    { key:"impr", label:"Impr.", visible:true },
-    { key:"reach", label:"Reach", visible:true },
-    { key:"clicks", label:"Clicks", visible:true },
-    { key:"leads", label:"Leads", visible:true },
-    { key:"cpl", label:"CPL", visible:true },
-    { key:"views", label:"Views", visible:true },
-    { key:"eng", label:"Eng.", visible:true },
-    { key:"ctr", label:"CTR", visible:true },
-    { key:"cpc", label:"CPC", visible:true },
-    { key:"cpm", label:"CPM", visible:true },
-  ]);
+  const [cols, setCols] = useState<ColumnDef[]>(DEFAULT_COLUMNS);
 
-  // Load saved state on mount
-  useEffect(() => {
-    const savedState = loadState();
-    if (savedState) {
-      if (savedState.totalBudget) setTotalBudget(savedState.totalBudget);
-      if (savedState.currency) setCurrency(savedState.currency);
-      if (savedState.market) setMarket(savedState.market);
-      if (savedState.goal) setGoal(savedState.goal);
-      if (savedState.niche) setNiche(savedState.niche);
-      if (savedState.leadToSalePercent) setLeadToSalePercent(savedState.leadToSalePercent);
-      if (savedState.revenuePerSale) setRevenuePerSale(savedState.revenuePerSale);
-      if (savedState.selectedPlatforms) setSelectedPlatforms(savedState.selectedPlatforms);
-      if (savedState.manualSplit !== undefined) setManualSplit(savedState.manualSplit);
-      if (savedState.platformWeights) setPlatformWeights(savedState.platformWeights);
-      if (savedState.includeAll !== undefined) setIncludeAll(savedState.includeAll);
-      if (savedState.manualCPL !== undefined) setManualCPL(savedState.manualCPL);
-      if (savedState.platformCPLs) setPlatformCPLs(savedState.platformCPLs);
-    }
-  }, []);
-
-  // Keep mode in sync with manualSplit
-  useEffect(() => setMode(manualSplit ? 'manual' : 'auto'), [manualSplit]);
-  useEffect(() => setManualSplit(mode === 'manual'), [mode]);
-
-  // When entering manual, auto helper must be off for clarity
-  useEffect(() => {
-    if (mode === 'manual' && includeAll) setIncludeAll(false);
-  }, [mode, includeAll]);
-
-  // Save state on changes
-  useEffect(() => {
-    const state: AppState = {
-      totalBudget,
-      currency,
-      market,
-      goal,
-      niche,
-      leadToSalePercent,
-      revenuePerSale,
-      selectedPlatforms,
-      manualSplit,
-      platformWeights,
-      includeAll,
-      manualCPL,
-      platformCPLs
-    };
-    saveState(state);
-  }, [
+  const {
     totalBudget,
     currency,
     market,
@@ -123,276 +71,73 @@ function App() {
     leadToSalePercent,
     revenuePerSale,
     selectedPlatforms,
-    manualSplit,
-    platformWeights,
+    mode,
     includeAll,
-    manualCPL,
-    platformCPLs
-  ]);
-
-  // Handle niche change
-  const handleNicheChange = useCallback((newNiche: string) => {
-    setNiche(newNiche);
-    const defaults = NICHE_DEFAULTS[newNiche];
-    if (defaults) {
-      setLeadToSalePercent(defaults.l2s);
-      setRevenuePerSale(defaults.rev);
-    }
-  }, []);
-
-  // Calculate results
-  const results = useMemo(() => calculateResults({
-    totalBudget,
-    selectedPlatforms,
-    goal,
-    market,
-    leadToSalePercent,
-    revenuePerSale,
-    manualSplit,
     platformWeights,
-    includeAll,
+    platformCPLs,
     manualCPL,
-    platformCPLs
-  }), [
-    totalBudget,
-    selectedPlatforms,
-    goal,
-    market,
-    leadToSalePercent,
-    revenuePerSale,
-    manualSplit,
-    platformWeights,
-    includeAll,
-    manualCPL,
-    platformCPLs
-  ]);
+    setTotalBudget,
+    setCurrency,
+    setMarket,
+    setGoal,
+    handleNicheChange,
+    setLeadToSalePercent,
+    setRevenuePerSale,
+    togglePlatform,
+    setMode,
+    setIncludeAll,
+    updatePlatformWeights,
+    setManualCPL,
+    setPlatformCPLs,
+  } = planner;
 
-  const totals = useMemo(() => calculateTotals(results), [results]);
-  const recommendations = useMemo(() => generateRecommendations(results), [results]);
-  const platformNames = useMemo(() => {
-    const map: Record<string, string> = { ...PLATFORM_NAME_MAP };
-    selectedPlatforms.forEach((platform) => {
-      if (!map[platform]) {
-        map[platform] = PLATFORM_LABELS[platform] || platform;
-      }
-    });
-    return map;
-  }, [selectedPlatforms]);
-
-  // Export CSV
-  // Professional export menu
-  const [exportOpen, setExportOpen] = useState(false);
-  const [exportPaper, setExportPaper] = useState<'a4'|'letter'>('a4');
-  const [exportName, setExportName] = useState(`media-plan-${new Date().toISOString().slice(0,10)}`);
-  const [includeAssumptions, setIncludeAssumptions] = useState(true);
-  const [isExporting, setIsExporting] = useState(false);
-  const runExport = async (fmt: 'pdf'|'xlsx'|'csv') => {
-    if (isExporting) return;
-    setIsExporting(true);
-    let objectUrl: string | undefined;
-    try {
-      const payload: ExportPayload = {
-        advertiser: 'Your Organization',
-        taxId: undefined,
-        currency: currency as any,
-        periodLabel: new Date().toLocaleDateString('en-GB', { day:'2-digit', month:'short', year:'numeric' }),
-        preparedAt: new Date(),
-        statementId: `MPL-${Date.now()}`,
-        totals: { budget: totals.budget, clicks: totals.clicks, leads: totals.leads, roas: totals.roas || 0 },
-        rows: results.map(r => ({
-          platform: PLATFORM_LABELS[r.platform] || r.platform,
-          budget: r.budget,
-          impressions: r.impressions,
-          reach: r.reach,
-          clicks: r.clicks,
-          leads: r.leads,
-          cpl: r.cpl ?? null,
-          views: r.views ?? null,
-          eng: r.engagements ?? null,
-          ctr: r.ctr ?? null,
-          cpc: r.cpc ?? null,
-          cpm: r.cpm ?? null,
-          sales: r.sales ?? null,
-          cac: r.cac ?? null,
-          revenue: r.revenue ?? null,
-        })),
-        assumptions: includeAssumptions ? { market, goal, niche, currency } : undefined,
-      };
-      let blob: Blob;
-      if (fmt === 'pdf') blob = await (await import('./export/pdf')).exportPDF(payload);
-      else if (fmt === 'xlsx') blob = await (await import('./export/xlsx')).exportXLSX(payload);
-      else blob = await (await import('./export/csv')).exportCSV(payload);
-      const ext = fmt === 'pdf' ? 'pdf' : (fmt === 'xlsx' ? 'xlsx' : 'csv');
-      const safeName = sanitizeFilename(exportName) || `media-plan-${new Date().toISOString().slice(0,10)}`;
-      const link = typeof document !== 'undefined' ? document.createElement('a') : null;
-      if (!link) return;
-      objectUrl = URL.createObjectURL(blob);
-      link.href = objectUrl;
-      link.download = `${safeName}.${ext}`;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-    } catch (err) {
-      console.error('Failed to export', err);
-      if (typeof window !== 'undefined' && typeof window.alert === 'function') {
-        window.alert('Sorry, something went wrong while exporting. Please try again.');
-      }
-    } finally {
-      if (objectUrl) {
-        const url = objectUrl;
-        setTimeout(() => URL.revokeObjectURL(url), 1000);
-      }
-      setExportOpen(false);
-      setIsExporting(false);
-    }
-  };
-
-  const fxOk = hasRate(currency as any);
-
-  // Prepare data for charts and table
-  const rowsFmt = results.map(r => ({
-    platform: r.platform,
-    name: PLATFORM_LABELS[r.platform] || r.platform,
-    budget: `${fmt(r.budget, 0)} ${currency}`,
-    impr: fmt(r.impressions, 0),
-    reach: fmt(r.reach, 0),
-    clicks: fmt(r.clicks, 0),
-    leads: fmt(r.leads, 0),
-    cpl: fmt(r.cpl, 2),
-    views: r.views ? fmt(r.views, 0) : "—",
-    eng: r.engagements ? fmt(r.engagements, 0) : "—",
-    ctr: `${fmt(r.ctr * 100, 2)}%`,
-    cpc: fmt(r.cpc, 2),
-    cpm: fmt(r.cpm, 2),
-  }));
-
-  const totalsFmt = {
-    budget: `${fmt(totals.budget, 0)} ${currency}`,
-    impr: fmt(totals.impressions, 0),
-    reach: fmt(totals.reach, 0),
-    clicks: fmt(totals.clicks, 0),
-    leads: fmt(totals.leads, 0),
-    cpl: fmt(totals.cpl, 2),
-    views: totals.views ? fmt(totals.views, 0) : "—",
-    eng: totals.engagements ? fmt(totals.engagements, 0) : "—",
-    ctr: "—",
-    cpc: "—",
-    cpm: "—",
-    roas: totals.roas ? `${fmt(totals.roas, 2)}x` : "—",
-  };
-
-  // Charts data (Budget Split)
-  const selected = selectedPlatforms;
-  const manualOn = manualSplit;
-  const includeAllMin10 = includeAll;
-  const manualPct: Record<string, number> = selected.reduce((acc, p) => {
-    acc[p] = Math.max(0, platformWeights[p as Platform] ?? 0);
-    return acc;
-  }, {} as Record<string, number>);
-  const autoWeights: Record<string, number> = selected.reduce((acc, p) => {
-    const r = results.find(x => x.platform === p);
-    acc[p] = Math.max(0, (r as any)?.weight ?? 0);
-    return acc;
-  }, {} as Record<string, number>);
-
-  const { weights: displayWeights, manualSum } = deriveDisplayWeights(
-    selected as unknown as string[],
-    manualOn,
-    manualPct,
-    autoWeights,
-    includeAllMin10
+  const selectedNames = useMemo(
+    () =>
+      selectedPlatforms.reduce((acc, platform) => {
+        acc[platform] = derived.platformNames[platform] || PLATFORM_NAME_MAP[platform] || platform;
+        return acc;
+      }, {} as Record<string, string>),
+    [derived.platformNames, selectedPlatforms]
   );
 
-  const donutData = selected.map((p) => ({
-    name: PLATFORM_LABELS[p] || p,
-    value: Math.round((displayWeights[p] ?? 0) * 100),
-    platform: p,
-  })).filter(d => d.value > 0 || selected.length === 1);
+  const pctMap = useMemo(
+    () =>
+      selectedPlatforms.reduce((acc, platform) => {
+        acc[platform] = Math.max(0, platformWeights[platform] ?? 0);
+        return acc;
+      }, {} as Record<string, number>),
+    [platformWeights, selectedPlatforms]
+  );
 
-  const centerValue = `${fmt(totals.budget || 0, 0)} ${currency}`;
-  const centerLabel = manualOn
-    ? (manualSum === 100 ? 'Manual split' : `Manual split (normalized from ${Math.round(manualSum)}%)`)
-    : (includeAllMin10 ? 'Auto split (≥10% each)' : 'Auto split');
+  const cplMap = useMemo(
+    () =>
+      selectedPlatforms.reduce((acc, platform) => {
+        const value = platformCPLs[platform];
+        if (typeof value === 'number') acc[platform] = value;
+        return acc;
+      }, {} as Record<string, number>),
+    [platformCPLs, selectedPlatforms]
+  );
 
+  const handleSetCplMap = useCallback(
+    (next: Record<string, number>) => {
+      const updated = {} as Record<Platform, number>;
+      Object.entries(next).forEach(([key, value]) => {
+        updated[key as Platform] = Math.max(0, Number(value) || 0);
+      });
+      setPlatformCPLs(updated);
+    },
+    [setPlatformCPLs]
+  );
 
-  const barsData = results.map(r => ({
-    name: PLATFORM_LABELS[r.platform] || r.platform,
-    value: Math.round(r.impressions || 0),
-    platform: r.platform,
-  }));
+  const fxOk = hasRate(currency as Cur);
 
   return (
     <div className="min-h-screen appBg">
-      {/* Header */}
-      <header className="appbar">
-        <div className="container py-4">
-          <div className="flex items-center justify-between">
-            <h1 className="h1">Media Plan Lite</h1>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setShowFx(true)}
-                className="btn"
-                style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
-                title="Review or update exchange rates"
-              >
-                <Settings size={14} />
-                <span>Manage FX</span>
-              </button>
-              <div style={{ position:'relative' }}>
-                <button
-                  onClick={()=> setExportOpen(v=>!v)}
-                  disabled={results.length === 0 || isExporting}
-                  className="btn primary"
-                  aria-haspopup="menu"
-                  aria-expanded={exportOpen}
-                  aria-busy={isExporting}
-                >
-                  <Download size={14} />
-                  {isExporting ? 'Exporting…' : 'Export'}
-                </button>
-                {exportOpen && (
-                  <div role="dialog" aria-modal="true" style={{ position:'absolute', right:0, marginTop:8, background:'#16171A', border:'1px solid var(--border)', borderRadius:12, padding:12, minWidth:260, zIndex:30 }}>
-                    <div style={{ display:'grid', gap:8 }}>
-                      <div>
-                        <div className="label">Filename</div>
-                        <input className="input" value={exportName} onChange={e=>setExportName(e.target.value)} />
-                      </div>
-                      <div>
-                        <div className="label">Paper (PDF)</div>
-                        <select className="select" value={exportPaper} onChange={e=>setExportPaper(e.target.value as any)}>
-                          <option value="a4">A4</option>
-                          <option value="letter">Letter</option>
-                        </select>
-                      </div>
-                      <label className="chip" style={{ justifyContent:'space-between' }}>
-                        Include assumptions (XLSX)
-                        <input type="checkbox" checked={includeAssumptions} onChange={e=>setIncludeAssumptions(e.target.checked)} />
-                      </label>
-                      <div style={{ display:'grid', gap:6 }}>
-                        <button className="secBtn" onClick={()=>runExport('pdf')} disabled={isExporting}>
-                          {isExporting ? 'Exporting…' : 'Export PDF'}
-                        </button>
-                        <button className="secBtn" onClick={()=>runExport('xlsx')} disabled={isExporting}>
-                          {isExporting ? 'Exporting…' : 'Export XLSX'}
-                        </button>
-                        <button className="secBtn" onClick={()=>runExport('csv')} disabled={isExporting}>
-                          {isExporting ? 'Exporting…' : 'Export CSV'}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
+      <PlannerHeader onOpenFx={() => setShowFx(true)} exportControls={exportManager} />
 
       <main className="container section">
-
-        {/* Main Content Grid */}
         <div className="section grid md:grid-cols-[1.1fr_1fr] gap-5">
-          {/* Planner Panel */}
           <MediaPlannerCard
             totalBudget={totalBudget}
             currency={currency}
@@ -412,127 +157,57 @@ function App() {
             onNicheChange={handleNicheChange}
             onLeadToSaleChange={setLeadToSalePercent}
             onRevenuePerSaleChange={setRevenuePerSale}
-            onPlatformToggle={(platform) => {
-              if (selectedPlatforms.includes(platform)) {
-                setSelectedPlatforms(selectedPlatforms.filter(p => p !== platform));
-              } else {
-                setSelectedPlatforms([...selectedPlatforms, platform]);
-              }
-            }}
+            onPlatformToggle={togglePlatform}
             onModeChange={setMode}
             onIncludeAllChange={setIncludeAll}
             nicheOptions={Object.keys(NICHE_DEFAULTS)}
           />
 
-          {/* FX Warning */}
-          {!fxOk && (
-            <div className="rowCard warn" style={{marginTop:8}}>
-      <div>
-                <div className="title">FX rate missing for {currency}.</div>
-                <div className="sub">We'll assume your CPM/CPC/CPL are already in {currency}. Set a rate to normalize math.</div>
-              </div>
-              <button className="secBtn" onClick={()=>setShowFx(true)}>Manage FX</button>
-            </div>
-          )}
+          {!fxOk && <FxWarning currency={currency} onManageFx={() => setShowFx(true)} />}
 
-          {/* FX Manager Modal */}
-          {showFx && <FxManager current={currency as any} onClose={()=>setShowFx(false)} />}
+          {showFx && <FxManager current={currency} onClose={() => setShowFx(false)} />}
 
-          {/* Platform Allocation Card */}
           <AllocationCard
-            selected={selectedPlatforms as unknown as string[]}
-            names={platformNames}
+            selected={selectedPlatforms}
+            names={selectedNames}
             mode={mode}
-            pctMap={selectedPlatforms.reduce((acc, p)=>{ acc[p]= Math.max(0, platformWeights[p]??0); return acc; }, {} as Record<string,number>)}
-            setPctMap={(next)=>{
-              const updated = { ...platformWeights } as Record<Platform, number>;
-              (Object.keys(next) as string[]).forEach(k=>{ updated[k as Platform] = Math.max(0, Number((next as any)[k])||0); });
-              setPlatformWeights(updated);
-            }}
+            pctMap={pctMap}
+            setPctMap={updatePlatformWeights}
           />
+
           <CostOverridesCard
-            selected={selectedPlatforms as unknown as string[]}
-            names={platformNames}
+            selected={selectedPlatforms}
+            names={selectedNames}
             currency={currency}
             manualCpl={manualCPL}
             setManualCpl={setManualCPL}
-            cplMap={platformCPLs as unknown as Record<string, number>}
-            setCplMap={(next)=> setPlatformCPLs(next as Record<Platform, number>)}
+            cplMap={cplMap}
+            setCplMap={handleSetCplMap}
           />
 
-          {/* Charts Panel */}
           <div className="chart-stack">
-            <BudgetDonutPro
-              data={donutData}
-              centerValue={centerValue}
-              centerLabel={centerLabel}
-            />
-            <ImpressionsBarsPro data={barsData} title="IMPRESSIONS" />
+            <BudgetDonutPro data={derived.donutData} centerValue={derived.centerValue} centerLabel={derived.centerLabel} />
+            <ImpressionsBarsPro data={derived.barsData} title="IMPRESSIONS" />
           </div>
         </div>
 
-        {/* KPI Cards */}
-        {results.length > 0 && (
-          <KpiCards totals={totals} currency={currency} />
+        {derived.results.length > 0 && <KpiCards totals={derived.totals} currency={currency} />}
+
+        {derived.results.length > 0 && (
+          <ResultsByPlatformCard rows={derived.rowsFmt} totals={derived.totalsFmt} showInlineKpis={false} columns={cols} onOpenColumns={() => setColumnsOpen(true)} />
         )}
 
-        {/* Results by Platform */}
-        {results.length > 0 && (
-          <ResultsByPlatformCard 
-            rows={rowsFmt} 
-            totals={totalsFmt} 
-            showInlineKpis={false}
-            columns={cols}
-            onOpenColumns={() => setColumnsOpen(true)}
+        {derived.results.length > 0 && derived.recommendations.length > 0 && (
+          <RecommendationsCard
+            items={derived.recommendations.map((rec) => `${PLATFORM_LABELS[rec.platform]}: ${rec.text}`)}
           />
         )}
 
-        {/* Recommendations */}
-        {results.length > 0 && recommendations.length > 0 && (
-          <RecommendationsCard 
-            items={recommendations.map(rec => `${PLATFORM_LABELS[rec.platform]}: ${rec.text}`)}
-          />
-        )}
-
-      {/* Columns Dialog */}
-      <ColumnsDialog
-        open={columnsOpen}
-        onClose={() => setColumnsOpen(false)}
-        cols={cols}
-        setCols={setCols}
-      />
+        <ColumnsDialog open={columnsOpen} onClose={() => setColumnsOpen(false)} cols={cols} setCols={setCols} />
       </main>
     </div>
   );
 }
 
-
-// KPI Cards Component
-function KpiCards({ totals, currency }: { totals: any; currency: string }) {
-  return (
-    <div className="kpiGroup">
-      <div className="kpiGrid">
-        <div className="kpiCell">
-          <div className="kpiLabel">$ Total Budget</div>
-          <div className="kpiValue">{formatCurrency(totals.budget, currency)}</div>
-        </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">⌖ Total Clicks</div>
-          <div className="kpiValue">{formatNumber(totals.clicks)}</div>
-        </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">🎯 Total Leads</div>
-          <div className="kpiValue">{formatNumber(totals.leads)}</div>
-        </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">📈 ROAS</div>
-          <div className="kpiValue">{Number.isFinite(totals?.roas) ? `${totals.roas.toFixed(2)}x` : '—'}</div>
-        </div>
-      </div>
-      </div>
-  );
-}
-
-
-
 export default App;
+

--- a/src/components/FxWarning.tsx
+++ b/src/components/FxWarning.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+type FxWarningProps = {
+  currency: string;
+  onManageFx: () => void;
+};
+
+export const FxWarning: FC<FxWarningProps> = ({ currency, onManageFx }) => (
+  <div className="rowCard warn" style={{ marginTop: 8 }}>
+    <div>
+      <div className="title">FX rate missing for {currency}.</div>
+      <div className="sub">
+        We'll assume your CPM/CPC/CPL are already in {currency}. Set a rate to normalize math.
+      </div>
+    </div>
+    <button className="secBtn" onClick={onManageFx}>
+      Manage FX
+    </button>
+  </div>
+);
+
+export default FxWarning;
+

--- a/src/components/KpiCards.tsx
+++ b/src/components/KpiCards.tsx
@@ -1,0 +1,38 @@
+import type { FC } from 'react';
+import { formatCurrency, formatNumber } from '../lib/utils';
+
+export type KpiCardsProps = {
+  totals: {
+    budget: number;
+    clicks: number;
+    leads: number;
+    roas?: number | null;
+  };
+  currency: string;
+};
+
+export const KpiCards: FC<KpiCardsProps> = ({ totals, currency }) => (
+  <div className="kpiGroup">
+    <div className="kpiGrid">
+      <div className="kpiCell">
+        <div className="kpiLabel">$ Total Budget</div>
+        <div className="kpiValue">{formatCurrency(totals.budget, currency)}</div>
+      </div>
+      <div className="kpiCell">
+        <div className="kpiLabel">⌖ Total Clicks</div>
+        <div className="kpiValue">{formatNumber(totals.clicks)}</div>
+      </div>
+      <div className="kpiCell">
+        <div className="kpiLabel">🎯 Total Leads</div>
+        <div className="kpiValue">{formatNumber(totals.leads)}</div>
+      </div>
+      <div className="kpiCell">
+        <div className="kpiLabel">📈 ROAS</div>
+        <div className="kpiValue">{Number.isFinite(totals?.roas) ? `${totals.roas?.toFixed(2)}x` : '—'}</div>
+      </div>
+    </div>
+  </div>
+);
+
+export default KpiCards;
+

--- a/src/components/PlannerHeader.tsx
+++ b/src/components/PlannerHeader.tsx
@@ -1,0 +1,128 @@
+import { Download, Settings } from 'lucide-react';
+import type { FC } from 'react';
+
+export type ExportControls = {
+  exportOpen: boolean;
+  toggleExport: () => void;
+  exportName: string;
+  setExportName: (value: string) => void;
+  exportPaper: 'a4' | 'letter';
+  setExportPaper: (value: 'a4' | 'letter') => void;
+  includeAssumptions: boolean;
+  setIncludeAssumptions: (value: boolean) => void;
+  isExporting: boolean;
+  canExport: boolean;
+  runExport: (format: 'pdf' | 'xlsx' | 'csv') => Promise<void>;
+};
+
+type PlannerHeaderProps = {
+  onOpenFx: () => void;
+  exportControls: ExportControls;
+};
+
+export const PlannerHeader: FC<PlannerHeaderProps> = ({ onOpenFx, exportControls }) => {
+  const {
+    exportOpen,
+    toggleExport,
+    exportName,
+    setExportName,
+    exportPaper,
+    setExportPaper,
+    includeAssumptions,
+    setIncludeAssumptions,
+    isExporting,
+    canExport,
+    runExport,
+  } = exportControls;
+
+  return (
+    <header className="appbar">
+      <div className="container py-4">
+        <div className="flex items-center justify-between">
+          <h1 className="h1">Media Plan Lite</h1>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onOpenFx}
+              className="btn"
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+              title="Review or update exchange rates"
+            >
+              <Settings size={14} />
+              <span>Manage FX</span>
+            </button>
+            <div style={{ position: 'relative' }}>
+              <button
+                onClick={toggleExport}
+                disabled={!canExport || isExporting}
+                className="btn primary"
+                aria-haspopup="menu"
+                aria-expanded={exportOpen}
+                aria-busy={isExporting}
+              >
+                <Download size={14} />
+                {isExporting ? 'Exporting…' : 'Export'}
+              </button>
+              {exportOpen && (
+                <div
+                  role="dialog"
+                  aria-modal="true"
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    marginTop: 8,
+                    background: '#16171A',
+                    border: '1px solid var(--border)',
+                    borderRadius: 12,
+                    padding: 12,
+                    minWidth: 260,
+                    zIndex: 30,
+                  }}
+                >
+                  <div style={{ display: 'grid', gap: 8 }}>
+                    <div>
+                      <div className="label">Filename</div>
+                      <input className="input" value={exportName} onChange={(e) => setExportName(e.target.value)} />
+                    </div>
+                    <div>
+                      <div className="label">Paper (PDF)</div>
+                      <select
+                        className="select"
+                        value={exportPaper}
+                        onChange={(e) => setExportPaper(e.target.value as 'a4' | 'letter')}
+                      >
+                        <option value="a4">A4</option>
+                        <option value="letter">Letter</option>
+                      </select>
+                    </div>
+                    <label className="chip" style={{ justifyContent: 'space-between' }}>
+                      Include assumptions (XLSX)
+                      <input
+                        type="checkbox"
+                        checked={includeAssumptions}
+                        onChange={(e) => setIncludeAssumptions(e.target.checked)}
+                      />
+                    </label>
+                    <div style={{ display: 'grid', gap: 6 }}>
+                      <button className="secBtn" onClick={() => runExport('pdf')} disabled={isExporting}>
+                        {isExporting ? 'Exporting…' : 'Export PDF'}
+                      </button>
+                      <button className="secBtn" onClick={() => runExport('xlsx')} disabled={isExporting}>
+                        {isExporting ? 'Exporting…' : 'Export XLSX'}
+                      </button>
+                      <button className="secBtn" onClick={() => runExport('csv')} disabled={isExporting}>
+                        {isExporting ? 'Exporting…' : 'Export CSV'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default PlannerHeader;
+

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,4 @@
+import type { calculateTotals } from '../lib/math';
+
+export type ReturnTypeOfCalculateTotals = ReturnType<typeof calculateTotals>;
+

--- a/src/hooks/useExportManager.ts
+++ b/src/hooks/useExportManager.ts
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { ExportPayload } from '../export';
+import { PLATFORM_LABELS } from '../lib/utils';
+import type { PlannerState } from './usePlannerState';
+import type { PlatformResult } from '../lib/math';
+import type { ReturnTypeOfCalculateTotals } from './types';
+
+const sanitizeFilename = (name: string) => {
+  const cleaned = name.trim().replace(/[\\/:*?"<>|]/g, '-');
+  const normalized = cleaned.replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized;
+};
+
+type ExportFormat = 'pdf' | 'xlsx' | 'csv';
+
+type ExportManagerArgs = {
+  state: PlannerState;
+  totals: ReturnTypeOfCalculateTotals;
+  results: PlatformResult[];
+};
+
+type ExportManagerApi = {
+  exportOpen: boolean;
+  toggleExport: () => void;
+  closeExport: () => void;
+  exportPaper: 'a4' | 'letter';
+  setExportPaper: (value: 'a4' | 'letter') => void;
+  exportName: string;
+  setExportName: (value: string) => void;
+  includeAssumptions: boolean;
+  setIncludeAssumptions: (value: boolean) => void;
+  isExporting: boolean;
+  canExport: boolean;
+  runExport: (format: ExportFormat) => Promise<void>;
+};
+
+export const useExportManager = ({ state, totals, results }: ExportManagerArgs): ExportManagerApi => {
+  const [exportOpen, setExportOpen] = useState(false);
+  const [exportPaper, setExportPaper] = useState<'a4' | 'letter'>('a4');
+  const [exportName, setExportName] = useState(`media-plan-${new Date().toISOString().slice(0, 10)}`);
+  const [includeAssumptions, setIncludeAssumptions] = useState(true);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const canExport = useMemo(() => results.length > 0, [results.length]);
+
+  const closeExport = useCallback(() => setExportOpen(false), []);
+  const toggleExport = useCallback(() => setExportOpen((open) => !open), []);
+
+  const runExport = useCallback(
+    async (fmt: ExportFormat) => {
+      if (isExporting || !canExport) return;
+      setIsExporting(true);
+      let objectUrl: string | undefined;
+
+      try {
+        const payload: ExportPayload = {
+          advertiser: 'Your Organization',
+          taxId: undefined,
+          currency: state.currency as ExportPayload['currency'],
+          periodLabel: new Date().toLocaleDateString('en-GB', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric',
+          }),
+          preparedAt: new Date(),
+          statementId: `MPL-${Date.now()}`,
+          totals: {
+            budget: totals.budget,
+            clicks: totals.clicks,
+            leads: totals.leads,
+            roas: totals.roas || 0,
+          },
+          rows: results.map((r) => ({
+            platform: PLATFORM_LABELS[r.platform] || r.platform,
+            budget: r.budget,
+            impressions: r.impressions,
+            reach: r.reach,
+            clicks: r.clicks,
+            leads: r.leads,
+            cpl: r.cpl ?? null,
+            views: r.views ?? null,
+            eng: r.engagements ?? null,
+            ctr: r.ctr ?? null,
+            cpc: r.cpc ?? null,
+            cpm: r.cpm ?? null,
+            sales: r.sales ?? null,
+            cac: r.cac ?? null,
+            revenue: r.revenue ?? null,
+          })),
+          assumptions: includeAssumptions
+            ? {
+                market: state.market,
+                goal: state.goal,
+                niche: state.niche,
+                currency: state.currency,
+              }
+            : undefined,
+        };
+
+        let blob: Blob;
+        if (fmt === 'pdf') blob = await (await import('../export/pdf')).exportPDF(payload);
+        else if (fmt === 'xlsx') blob = await (await import('../export/xlsx')).exportXLSX(payload);
+        else blob = await (await import('../export/csv')).exportCSV(payload);
+
+        const ext = fmt === 'pdf' ? 'pdf' : fmt === 'xlsx' ? 'xlsx' : 'csv';
+        const safeName = sanitizeFilename(exportName) || `media-plan-${new Date().toISOString().slice(0, 10)}`;
+        const link = typeof document !== 'undefined' ? document.createElement('a') : null;
+        if (!link) return;
+
+        objectUrl = URL.createObjectURL(blob);
+        link.href = objectUrl;
+        link.download = `${safeName}.${ext}`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      } catch (err) {
+        console.error('Failed to export', err);
+        if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+          window.alert('Sorry, something went wrong while exporting. Please try again.');
+        }
+      } finally {
+        if (objectUrl) {
+          const url = objectUrl;
+          setTimeout(() => URL.revokeObjectURL(url), 1000);
+        }
+        setIsExporting(false);
+        closeExport();
+      }
+    },
+    [canExport, closeExport, exportName, includeAssumptions, isExporting, results, state, totals]
+  );
+
+  return {
+    exportOpen,
+    toggleExport,
+    closeExport,
+    exportPaper,
+    setExportPaper,
+    exportName,
+    setExportName,
+    includeAssumptions,
+    setIncludeAssumptions,
+    isExporting,
+    canExport,
+    runExport,
+  };
+};
+

--- a/src/hooks/usePlannerDerivedData.ts
+++ b/src/hooks/usePlannerDerivedData.ts
@@ -1,0 +1,204 @@
+import { useMemo } from 'react';
+import type { Platform } from '../lib/assumptions';
+import { PLATFORM_LABELS, formatCurrency, formatNumber } from '../lib/utils';
+import { calculateResults, calculateTotals } from '../lib/math';
+import { generateRecommendations } from '../lib/recommendations';
+import { deriveDisplayWeights } from '../utils/split';
+import { fmt } from '../utils/format';
+import type { PlannerState } from './usePlannerState';
+
+export type ResultsRow = {
+  platform: string;
+  name: string;
+  budget: string;
+  impr: string;
+  reach: string;
+  clicks: string | number;
+  leads: string | number;
+  cpl: string | number;
+  views?: string | number;
+  eng?: string | number;
+  ctr: string;
+  cpc: string | number;
+  cpm: string | number;
+};
+
+export type DerivedData = {
+  results: ReturnType<typeof calculateResults>;
+  totals: ReturnType<typeof calculateTotals>;
+  recommendations: ReturnType<typeof generateRecommendations>;
+  platformNames: Record<string, string>;
+  rowsFmt: ResultsRow[];
+  totalsFmt: Partial<ResultsRow> & { roas: string };
+  donutData: Array<{ name: string; value: number; platform: string }>;
+  centerValue: string;
+  centerLabel: string;
+  barsData: Array<{ name: string; value: number; platform: Platform }>;
+};
+
+export type PlannerDerivedDataArgs = PlannerState;
+
+export const usePlannerDerivedData = (state: PlannerDerivedDataArgs): DerivedData => {
+  const {
+    totalBudget,
+    selectedPlatforms,
+    goal,
+    market,
+    leadToSalePercent,
+    revenuePerSale,
+    manualSplit,
+    platformWeights,
+    includeAll,
+    manualCPL,
+    platformCPLs,
+    currency,
+    mode,
+  } = state;
+
+  const results = useMemo(
+    () =>
+      calculateResults({
+        totalBudget,
+        selectedPlatforms,
+        goal,
+        market,
+        leadToSalePercent,
+        revenuePerSale,
+        manualSplit,
+        platformWeights,
+        includeAll,
+        manualCPL,
+        platformCPLs,
+      }),
+    [
+      totalBudget,
+      selectedPlatforms,
+      goal,
+      market,
+      leadToSalePercent,
+      revenuePerSale,
+      manualSplit,
+      platformWeights,
+      includeAll,
+      manualCPL,
+      platformCPLs,
+    ]
+  );
+
+  const totals = useMemo(() => calculateTotals(results), [results]);
+  const recommendations = useMemo(() => generateRecommendations(results), [results]);
+
+  const platformNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    selectedPlatforms.forEach((platform) => {
+      map[platform] = PLATFORM_LABELS[platform] || platform;
+    });
+    return map;
+  }, [selectedPlatforms]);
+
+  const rowsFmt = useMemo(
+    () =>
+      results.map<ResultsRow>((r) => ({
+        platform: r.platform,
+        name: PLATFORM_LABELS[r.platform] || r.platform,
+        budget: `${fmt(r.budget, 0)} ${currency}`,
+        impr: fmt(r.impressions, 0),
+        reach: fmt(r.reach, 0),
+        clicks: fmt(r.clicks, 0),
+        leads: fmt(r.leads, 0),
+        cpl: fmt(r.cpl, 2),
+        views: r.views ? fmt(r.views, 0) : '—',
+        eng: r.engagements ? fmt(r.engagements, 0) : '—',
+        ctr: `${fmt((r.ctr || 0) * 100, 2)}%`,
+        cpc: fmt(r.cpc, 2),
+        cpm: fmt(r.cpm, 2),
+      })),
+    [currency, results]
+  );
+
+  const totalsFmt = useMemo(
+    () => ({
+      budget: `${fmt(totals.budget, 0)} ${currency}`,
+      impr: fmt(totals.impressions, 0),
+      reach: fmt(totals.reach, 0),
+      clicks: fmt(totals.clicks, 0),
+      leads: fmt(totals.leads, 0),
+      cpl: fmt(totals.cpl, 2),
+      views: totals.views ? fmt(totals.views, 0) : '—',
+      eng: totals.engagements ? fmt(totals.engagements, 0) : '—',
+      ctr: '—',
+      cpc: '—',
+      cpm: '—',
+      roas: totals.roas ? `${fmt(totals.roas, 2)}x` : '—',
+    }),
+    [currency, totals]
+  );
+
+  const chartData = useMemo(() => {
+    const manualOn = mode === 'manual';
+    const manualPct: Record<string, number> = selectedPlatforms.reduce((acc, platform) => {
+      acc[platform] = Math.max(0, platformWeights[platform] ?? 0);
+      return acc;
+    }, {} as Record<string, number>);
+
+    const autoWeights: Record<string, number> = selectedPlatforms.reduce((acc, platform) => {
+      const result = results.find((r) => r.platform === platform);
+      acc[platform] = Math.max(0, result?.weight ?? 0);
+      return acc;
+    }, {} as Record<string, number>);
+
+    const { weights, manualSum } = deriveDisplayWeights(
+      selectedPlatforms as unknown as string[],
+      manualOn,
+      manualPct,
+      autoWeights,
+      includeAll
+    );
+
+    const donutData = selectedPlatforms
+      .map((platform) => ({
+        name: PLATFORM_LABELS[platform] || platform,
+        value: Math.round((weights[platform] ?? 0) * 100),
+        platform,
+      }))
+      .filter((item) => item.value > 0 || selectedPlatforms.length === 1);
+
+    const centerValue = `${fmt(totals.budget || 0, 0)} ${currency}`;
+    const centerLabel = manualOn
+      ? manualSum === 100
+        ? 'Manual split'
+        : `Manual split (normalized from ${Math.round(manualSum)}%)`
+      : includeAll
+      ? 'Auto split (≥10% each)'
+      : 'Auto split';
+
+    const barsData = results.map((r) => ({
+      name: PLATFORM_LABELS[r.platform] || r.platform,
+      value: Math.round(r.impressions || 0),
+      platform: r.platform,
+    }));
+
+    return { donutData, centerValue, centerLabel, barsData };
+  }, [currency, includeAll, mode, results, selectedPlatforms, totals.budget, platformWeights]);
+
+  return {
+    results,
+    totals,
+    recommendations,
+    platformNames,
+    rowsFmt,
+    totalsFmt,
+    donutData: chartData.donutData,
+    centerValue: chartData.centerValue,
+    centerLabel: chartData.centerLabel,
+    barsData: chartData.barsData,
+  };
+};
+
+export const summarizeTotals = (totals: ReturnType<typeof calculateTotals>, currency: string) => ({
+  totalBudget: formatCurrency(totals.budget, currency),
+  totalClicks: formatNumber(totals.clicks),
+  totalLeads: formatNumber(totals.leads),
+  roas: Number.isFinite(totals?.roas) ? `${totals.roas?.toFixed(2)}x` : '—',
+});
+

--- a/src/hooks/usePlannerState.ts
+++ b/src/hooks/usePlannerState.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Currency, Goal, Market, Platform } from '../lib/assumptions';
+import { NICHE_DEFAULTS } from '../lib/assumptions';
+import type { AppState } from '../lib/storage';
+import { loadState, saveState } from '../lib/storage';
+
+export type PlannerState = {
+  totalBudget: number;
+  currency: Currency;
+  market: Market;
+  goal: Goal;
+  niche: string;
+  leadToSalePercent: number;
+  revenuePerSale: number;
+  selectedPlatforms: Platform[];
+  manualSplit: boolean;
+  platformWeights: Record<Platform, number>;
+  includeAll: boolean;
+  manualCPL: boolean;
+  platformCPLs: Record<Platform, number>;
+  mode: 'auto' | 'manual';
+};
+
+export type PlannerStateApi = PlannerState & {
+  setTotalBudget: (value: number) => void;
+  setCurrency: (value: Currency) => void;
+  setMarket: (value: Market) => void;
+  setGoal: (value: Goal) => void;
+  setNiche: (value: string) => void;
+  setLeadToSalePercent: (value: number) => void;
+  setRevenuePerSale: (value: number) => void;
+  setSelectedPlatforms: (value: Platform[]) => void;
+  setManualSplit: (value: boolean) => void;
+  setPlatformWeights: (value: Record<Platform, number>) => void;
+  setIncludeAll: (value: boolean) => void;
+  setManualCPL: (value: boolean) => void;
+  setPlatformCPLs: (value: Record<Platform, number>) => void;
+  setMode: (value: 'auto' | 'manual') => void;
+  handleNicheChange: (niche: string) => void;
+  togglePlatform: (platform: Platform) => void;
+  updatePlatformWeights: (next: Record<string, number>) => void;
+};
+
+const DEFAULT_PLATFORMS: Platform[] = ['FACEBOOK', 'GOOGLE_SEARCH'];
+
+export const usePlannerState = (): PlannerStateApi => {
+  const [totalBudget, setTotalBudget] = useState(10000);
+  const [currency, setCurrency] = useState<Currency>('USD');
+  const [market, setMarket] = useState<Market>('Egypt');
+  const [goal, setGoal] = useState<Goal>('LEADS');
+  const [niche, setNiche] = useState('Generic');
+  const [leadToSalePercent, setLeadToSalePercent] = useState(20);
+  const [revenuePerSale, setRevenuePerSale] = useState(800);
+  const [selectedPlatforms, setSelectedPlatforms] = useState<Platform[]>(DEFAULT_PLATFORMS);
+  const [manualSplit, setManualSplit] = useState(false);
+  const [platformWeights, setPlatformWeights] = useState<Record<Platform, number>>({} as Record<Platform, number>);
+  const [includeAll, setIncludeAll] = useState(false);
+  const [manualCPL, setManualCPL] = useState(false);
+  const [platformCPLs, setPlatformCPLs] = useState<Record<Platform, number>>({} as Record<Platform, number>);
+  const [mode, setMode] = useState<'auto' | 'manual'>(manualSplit ? 'manual' : 'auto');
+
+  useEffect(() => {
+    const savedState = loadState();
+    if (!savedState) return;
+
+    const applyIfDefined = <T,>(value: T | undefined, setter: (v: T) => void) => {
+      if (value !== undefined) setter(value);
+    };
+
+    applyIfDefined(savedState.totalBudget, setTotalBudget);
+    applyIfDefined(savedState.currency as Currency | undefined, setCurrency);
+    applyIfDefined(savedState.market as Market | undefined, setMarket);
+    applyIfDefined(savedState.goal as Goal | undefined, setGoal);
+    applyIfDefined(savedState.niche, setNiche);
+    applyIfDefined(savedState.leadToSalePercent, setLeadToSalePercent);
+    applyIfDefined(savedState.revenuePerSale, setRevenuePerSale);
+    applyIfDefined(savedState.selectedPlatforms as Platform[] | undefined, setSelectedPlatforms);
+    applyIfDefined(savedState.manualSplit, setManualSplit);
+    applyIfDefined(savedState.platformWeights as Record<Platform, number> | undefined, setPlatformWeights);
+    applyIfDefined(savedState.includeAll, setIncludeAll);
+    applyIfDefined(savedState.manualCPL, setManualCPL);
+    applyIfDefined(savedState.platformCPLs as Record<Platform, number> | undefined, setPlatformCPLs);
+  }, []);
+
+  useEffect(() => setMode(manualSplit ? 'manual' : 'auto'), [manualSplit]);
+  useEffect(() => setManualSplit(mode === 'manual'), [mode]);
+
+  useEffect(() => {
+    if (mode === 'manual' && includeAll) {
+      setIncludeAll(false);
+    }
+  }, [mode, includeAll]);
+
+  useEffect(() => {
+    const state: AppState = {
+      totalBudget,
+      currency,
+      market,
+      goal,
+      niche,
+      leadToSalePercent,
+      revenuePerSale,
+      selectedPlatforms,
+      manualSplit,
+      platformWeights,
+      includeAll,
+      manualCPL,
+      platformCPLs,
+    };
+    saveState(state);
+  }, [
+    totalBudget,
+    currency,
+    market,
+    goal,
+    niche,
+    leadToSalePercent,
+    revenuePerSale,
+    selectedPlatforms,
+    manualSplit,
+    platformWeights,
+    includeAll,
+    manualCPL,
+    platformCPLs,
+  ]);
+
+  const handleNicheChange = useCallback((newNiche: string) => {
+    setNiche(newNiche);
+    const defaults = NICHE_DEFAULTS[newNiche];
+    if (defaults) {
+      setLeadToSalePercent(defaults.l2s);
+      setRevenuePerSale(defaults.rev);
+    }
+  }, []);
+
+  const togglePlatform = useCallback((platform: Platform) => {
+    setSelectedPlatforms((prev) =>
+      prev.includes(platform)
+        ? prev.filter((p) => p !== platform)
+        : [...prev, platform]
+    );
+  }, []);
+
+  const updatePlatformWeights = useCallback((next: Record<string, number>) => {
+    setPlatformWeights((prev) => {
+      const updated = { ...prev } as Record<Platform, number>;
+      Object.entries(next).forEach(([key, value]) => {
+        updated[key as Platform] = Math.max(0, Number(value) || 0);
+      });
+      return updated;
+    });
+  }, []);
+
+  return {
+    totalBudget,
+    currency,
+    market,
+    goal,
+    niche,
+    leadToSalePercent,
+    revenuePerSale,
+    selectedPlatforms,
+    manualSplit,
+    platformWeights,
+    includeAll,
+    manualCPL,
+    platformCPLs,
+    mode,
+    setTotalBudget,
+    setCurrency,
+    setMarket,
+    setGoal,
+    setNiche,
+    setLeadToSalePercent,
+    setRevenuePerSale,
+    setSelectedPlatforms,
+    setManualSplit,
+    setPlatformWeights,
+    setIncludeAll,
+    setManualCPL,
+    setPlatformCPLs,
+    setMode,
+    handleNicheChange,
+    togglePlatform,
+    updatePlatformWeights,
+  };
+};
+


### PR DESCRIPTION
## Summary
- extract planner state persistence, derived data, and export menu logic into dedicated hooks
- split reusable UI including the header, FX warning, and KPI tiles into focused components
- simplify App.tsx by consuming the new hooks/components to keep render logic declarative

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cb03fc6a9c8321802029f38d80f62e