### PR TITLE
Fix ColumnsDialog state setter typing

### DIFF
--- a/src/components/ColumnsDialog.tsx
+++ b/src/components/ColumnsDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 export type ColumnDef = { key: string; label: string; visible: boolean };
 
@@ -8,7 +9,7 @@ export default function ColumnsDialog({
   open: boolean;
   onClose: () => void;
   cols: ColumnDef[];
-  setCols: (c: ColumnDef[]) => void;
+  setCols: Dispatch<SetStateAction<ColumnDef[]>>;
   storageKey?: string;
 }) {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- import the ColumnsDialog state setter types from React so the component accepts functional updates
- allow the production build to succeed, preventing the blank page caused by the broken state setter typing

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68cb284ce940832181a07cce74285a03