### PR TITLE
Refine planner hero and results layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './styles/theme.css'
 import './styles/charts.css'
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { motion, useInView, useReducedMotion } from 'framer-motion';
 import type { Platform, Goal, Market, Currency } from './lib/assumptions';
 import { NICHE_DEFAULTS } from './lib/assumptions';
 import { calculateResults, calculateTotals } from './lib/math';
@@ -23,6 +24,7 @@ import { CostOverridesCard } from './components/CostOverridesCard';
 import { FxManager } from './components/FxManager';
 import { hasRate } from './lib/fx';
 import MediaPlannerCard from './components/MediaPlannerCard';
+import { AnimatedCounter } from './components/ui/AnimatedCounter';
 
 const ALL_PLATFORMS: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'GOOGLE_SEARCH', 'GOOGLE_DISPLAY', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];
 const PLATFORM_NAME_MAP: Record<string, string> = Object.fromEntries(
@@ -252,6 +254,42 @@ function App() {
   };
 
   const fxOk = hasRate(currency as any);
+  const prefersReducedMotion = useReducedMotion();
+  const plannerRef = useRef<HTMLElement | null>(null);
+  const plannerInView = useInView(plannerRef, { margin: '-25% 0px -25% 0px' });
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.body.classList.toggle('planner-in', plannerInView);
+    return () => document.body.classList.remove('planner-in');
+  }, [plannerInView]);
+
+  const heroVariants = useMemo(() => ({
+    hidden: { opacity: 0, y: prefersReducedMotion ? 0 : 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.28, ease: [0.4, 0, 0.2, 1] } },
+  }), [prefersReducedMotion]);
+
+  const gridVariants = useMemo(() => (
+    prefersReducedMotion
+      ? { hidden: {}, visible: {} }
+      : { hidden: {}, visible: { transition: { staggerChildren: 0.04, delayChildren: 0.04 } } }
+  ), [prefersReducedMotion]);
+
+  const itemVariants = useMemo(() => ({
+    hidden: { opacity: 0, y: prefersReducedMotion ? 0 : 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.28, ease: [0.4, 0, 0.2, 1] } },
+  }), [prefersReducedMotion]);
+
+  const scrollToSection = useCallback((id: string) => {
+    if (typeof document === 'undefined') return;
+    const node = document.getElementById(id);
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, []);
+
+  const scrollToResults = useCallback(() => scrollToSection('results-section'), [scrollToSection]);
+  const scrollToAdvanced = useCallback(() => scrollToSection('advanced-planner'), [scrollToSection]);
 
   // Prepare data for charts and table
   const rowsFmt = results.map(r => ({
@@ -392,120 +430,164 @@ function App() {
         </div>
       </header>
 
-      <main className="container section">
-
-        {/* Main Content Grid */}
-        <div className="section grid md:grid-cols-[1.1fr_1fr] gap-5">
-          {/* Planner Panel */}
-          <MediaPlannerCard
-            totalBudget={totalBudget}
-            currency={currency}
-            market={market}
-            goal={goal}
-            niche={niche}
-            leadToSale={leadToSalePercent}
-            revenuePerSale={revenuePerSale}
-            platforms={ALL_PLATFORMS}
-            selectedPlatforms={selectedPlatforms}
-            mode={mode}
-            includeAll={includeAll}
-            onTotalBudgetChange={setTotalBudget}
-            onCurrencyChange={setCurrency}
-            onMarketChange={setMarket}
-            onGoalChange={setGoal}
-            onNicheChange={handleNicheChange}
-            onLeadToSaleChange={setLeadToSalePercent}
-            onRevenuePerSaleChange={setRevenuePerSale}
-            onPlatformToggle={(platform) => {
-              if (selectedPlatforms.includes(platform)) {
-                setSelectedPlatforms(selectedPlatforms.filter(p => p !== platform));
-              } else {
-                setSelectedPlatforms([...selectedPlatforms, platform]);
-              }
-            }}
-            onModeChange={setMode}
-            onIncludeAllChange={setIncludeAll}
-            nicheOptions={Object.keys(NICHE_DEFAULTS)}
-          />
-
-          {/* FX Warning */}
-          {!fxOk && (
-            <div className="rowCard warn" style={{marginTop:8}}>
-      <div>
-                <div className="title">FX rate missing for {currency}.</div>
-                <div className="sub">We'll assume your CPM/CPC/CPL are already in {currency}. Set a rate to normalize math.</div>
+      <main className="pb-24">
+        <motion.section
+          ref={plannerRef}
+          className="planner-shell"
+          variants={heroVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          <motion.div className="planner-grid" variants={gridVariants}>
+            <motion.div className="planner-copy" variants={itemVariants}>
+              <span className="planner-tag">Live preview</span>
+              <h2 className="planner-heading">Plan a sample campaign</h2>
+              <p className="planner-subcopy">
+                Tune budgets, objectives, and assumptions to watch cross-channel performance update instantly.
+              </p>
+              <p className="planner-note">
+                Numbers refresh in real time as you edit inputs. Scroll for full results or jump into advanced controls.
+              </p>
+              <div className="planner-cta">
+                <motion.button
+                  type="button"
+                  className="planner-btn planner-btn-primary"
+                  onClick={scrollToResults}
+                  whileHover={prefersReducedMotion ? undefined : { y: -1 }}
+                  whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+                >
+                  See full results →
+                </motion.button>
+                <motion.button
+                  type="button"
+                  className="planner-btn planner-link"
+                  onClick={scrollToAdvanced}
+                  whileHover={prefersReducedMotion ? undefined : { y: -1 }}
+                  whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+                >
+                  Open advanced planner →
+                </motion.button>
               </div>
-              <button className="secBtn" onClick={()=>setShowFx(true)}>Manage FX</button>
+            </motion.div>
+            <motion.div className="planner-card-wrap" variants={itemVariants}>
+              <MediaPlannerCard
+                totalBudget={totalBudget}
+                currency={currency}
+                market={market}
+                goal={goal}
+                niche={niche}
+                leadToSale={leadToSalePercent}
+                revenuePerSale={revenuePerSale}
+                platforms={ALL_PLATFORMS}
+                selectedPlatforms={selectedPlatforms}
+                mode={mode}
+                includeAll={includeAll}
+                onTotalBudgetChange={setTotalBudget}
+                onCurrencyChange={setCurrency}
+                onMarketChange={setMarket}
+                onGoalChange={setGoal}
+                onNicheChange={handleNicheChange}
+                onLeadToSaleChange={setLeadToSalePercent}
+                onRevenuePerSaleChange={setRevenuePerSale}
+                onPlatformToggle={(platform) => {
+                  if (selectedPlatforms.includes(platform)) {
+                    setSelectedPlatforms(selectedPlatforms.filter(p => p !== platform));
+                  } else {
+                    setSelectedPlatforms([...selectedPlatforms, platform]);
+                  }
+                }}
+                onModeChange={setMode}
+                onIncludeAllChange={setIncludeAll}
+                nicheOptions={Object.keys(NICHE_DEFAULTS)}
+              />
+            </motion.div>
+          </motion.div>
+        </motion.section>
+
+        <section id="results-section" className="section">
+          <div className="container flex flex-col gap-8">
+            {results.length > 0 && (
+              <div className="max-w-3xl">
+                <KpiCards totals={totals} currency={currency} />
+              </div>
+            )}
+            <div className="grid gap-6 lg:grid-cols-2">
+              <BudgetDonutPro
+                data={donutData}
+                centerValue={centerValue}
+                centerLabel={centerLabel}
+              />
+              <ImpressionsBarsPro data={barsData} title="IMPRESSIONS" />
             </div>
-          )}
-
-          {/* FX Manager Modal */}
-          {showFx && <FxManager current={currency as any} onClose={()=>setShowFx(false)} />}
-
-          {/* Platform Allocation Card */}
-          <AllocationCard
-            selected={selectedPlatforms as unknown as string[]}
-            names={platformNames}
-            mode={mode}
-            pctMap={selectedPlatforms.reduce((acc, p)=>{ acc[p]= Math.max(0, platformWeights[p]??0); return acc; }, {} as Record<string,number>)}
-            setPctMap={(next)=>{
-              const updated = { ...platformWeights } as Record<Platform, number>;
-              (Object.keys(next) as string[]).forEach(k=>{ updated[k as Platform] = Math.max(0, Number((next as any)[k])||0); });
-              setPlatformWeights(updated);
-            }}
-          />
-          <CostOverridesCard
-            selected={selectedPlatforms as unknown as string[]}
-            names={platformNames}
-            currency={currency}
-            manualCpl={manualCPL}
-            setManualCpl={setManualCPL}
-            cplMap={platformCPLs as unknown as Record<string, number>}
-            setCplMap={(next)=> setPlatformCPLs(next as Record<Platform, number>)}
-          />
-
-          {/* Charts Panel */}
-          <div className="chart-stack">
-            <BudgetDonutPro
-              data={donutData}
-              centerValue={centerValue}
-              centerLabel={centerLabel}
-            />
-            <ImpressionsBarsPro data={barsData} title="IMPRESSIONS" />
+            {results.length > 0 && (
+              <ResultsByPlatformCard
+                rows={rowsFmt}
+                totals={totalsFmt}
+                showInlineKpis={false}
+                columns={cols}
+                onOpenColumns={() => setColumnsOpen(true)}
+              />
+            )}
+            {results.length > 0 && recommendations.length > 0 && (
+              <RecommendationsCard
+                items={recommendations.map(rec => `${PLATFORM_LABELS[rec.platform]}: ${rec.text}`)}
+              />
+            )}
           </div>
-        </div>
+        </section>
 
-        {/* KPI Cards */}
-        {results.length > 0 && (
-          <KpiCards totals={totals} currency={currency} />
-        )}
+        <section id="advanced-planner" className="section">
+          <div className="container flex flex-col gap-6">
+            <div className="space-y-2">
+              <span className="planner-tag">Advanced planner</span>
+              <h2 className="text-2xl font-semibold text-white">Fine-tune allocations & assumptions</h2>
+              <p className="planner-note">
+                Switch to manual splits, override CPL assumptions, and manage FX in one place.
+              </p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <AllocationCard
+                selected={selectedPlatforms as unknown as string[]}
+                names={platformNames}
+                mode={mode}
+                pctMap={selectedPlatforms.reduce((acc, p)=>{ acc[p]= Math.max(0, platformWeights[p]??0); return acc; }, {} as Record<string,number>)}
+                setPctMap={(next)=>{
+                  const updated = { ...platformWeights } as Record<Platform, number>;
+                  (Object.keys(next) as string[]).forEach(k=>{ updated[k as Platform] = Math.max(0, Number((next as any)[k])||0); });
+                  setPlatformWeights(updated);
+                }}
+              />
+              <CostOverridesCard
+                selected={selectedPlatforms as unknown as string[]}
+                names={platformNames}
+                currency={currency}
+                manualCpl={manualCPL}
+                setManualCpl={setManualCPL}
+                cplMap={platformCPLs as unknown as Record<string, number>}
+                setCplMap={(next)=> setPlatformCPLs(next as Record<Platform, number>)}
+              />
+            </div>
+            {!fxOk && (
+              <div className="rowCard warn">
+                <div>
+                  <div className="title">FX rate missing for {currency}.</div>
+                  <div className="sub">We'll assume your CPM/CPC/CPL are already in {currency}. Set a rate to normalize math.</div>
+                </div>
+                <button className="secBtn" onClick={()=>setShowFx(true)}>Manage FX</button>
+              </div>
+            )}
+          </div>
+        </section>
+      </main>
 
-        {/* Results by Platform */}
-        {results.length > 0 && (
-          <ResultsByPlatformCard 
-            rows={rowsFmt} 
-            totals={totalsFmt} 
-            showInlineKpis={false}
-            columns={cols}
-            onOpenColumns={() => setColumnsOpen(true)}
-          />
-        )}
+      {showFx && <FxManager current={currency as any} onClose={()=>setShowFx(false)} />}
 
-        {/* Recommendations */}
-        {results.length > 0 && recommendations.length > 0 && (
-          <RecommendationsCard 
-            items={recommendations.map(rec => `${PLATFORM_LABELS[rec.platform]}: ${rec.text}`)}
-          />
-        )}
-
-      {/* Columns Dialog */}
       <ColumnsDialog
         open={columnsOpen}
         onClose={() => setColumnsOpen(false)}
         cols={cols}
         setCols={setCols}
       />
-      </main>
     </div>
   );
 }
@@ -513,30 +595,63 @@ function App() {
 
 // KPI Cards Component
 function KpiCards({ totals, currency }: { totals: any; currency: string }) {
+  const budget = typeof totals?.budget === 'number' ? totals.budget : null;
+  const reach = typeof totals?.reach === 'number' ? totals.reach : null;
+  const cpl = typeof totals?.cpl === 'number' ? totals.cpl : null;
+  const roas = typeof totals?.roas === 'number' ? totals.roas : null;
+
   return (
-    <div className="kpiGroup">
-      <div className="kpiGrid">
-        <div className="kpiCell">
-          <div className="kpiLabel">$ Total Budget</div>
-          <div className="kpiValue">{formatCurrency(totals.budget, currency)}</div>
+    <section className="kpi-panel">
+      <div className="planner-tag">KPI summary</div>
+      <div className="kpi-list">
+        <div className="kpi-row">
+          <div className="kpi-label">
+            <span className="kpi-dot kpi-dot--accent" />
+            <span>Budget</span>
+          </div>
+          <AnimatedCounter
+            value={budget}
+            formatter={(value) => formatCurrency(value, currency)}
+            className="kpi-value"
+          />
         </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">⌖ Total Clicks</div>
-          <div className="kpiValue">{formatNumber(totals.clicks)}</div>
+        <div className="kpi-row">
+          <div className="kpi-label">
+            <span className="kpi-dot kpi-dot--reach" />
+            <span>Reach</span>
+          </div>
+          <AnimatedCounter
+            value={reach}
+            formatter={(value) => formatNumber(value)}
+            className="kpi-value"
+          />
         </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">🎯 Total Leads</div>
-          <div className="kpiValue">{formatNumber(totals.leads)}</div>
+        <div className="kpi-row">
+          <div className="kpi-label">
+            <span className="kpi-dot kpi-dot--efficiency" />
+            <span>Efficiency (CPL)</span>
+          </div>
+          <AnimatedCounter
+            value={cpl}
+            formatter={(value) => formatCurrency(value, currency)}
+            className="kpi-value"
+          />
         </div>
-        <div className="kpiCell">
-          <div className="kpiLabel">📈 ROAS</div>
-          <div className="kpiValue">{Number.isFinite(totals?.roas) ? `${totals.roas.toFixed(2)}x` : '—'}</div>
+        <div className="kpi-row">
+          <div className="kpi-label">
+            <span className="kpi-dot kpi-dot--confidence" />
+            <span>Confidence (ROAS)</span>
+          </div>
+          <AnimatedCounter
+            value={roas}
+            formatter={(value) => `${value.toFixed(2)}x`}
+            className="kpi-value"
+          />
         </div>
       </div>
-      </div>
+    </section>
   );
 }
-
 
 
 export default App;

--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import type { Platform, Goal, Market, Currency } from '../lib/assumptions';
 import { PLATFORM_LABELS } from '../lib/utils';
 import SplitControlsRow from './SplitControlsRow';
@@ -28,13 +29,46 @@ type Props = {
 };
 
 export default function MediaPlannerCard(p: Props){
+  const id = useId();
+  const budgetId = `${id}-budget`;
+  const currencyId = `${id}-currency`;
+  const marketId = `${id}-market`;
+  const nicheId = `${id}-niche`;
+  const leadSaleId = `${id}-lead-sale`;
+  const revenueId = `${id}-revenue`;
+  const goalLabelId = `${id}-goal`;
+  const platformsLabelId = `${id}-platforms`;
+
+  const objectives: { value: Goal; label: string }[] = [
+    { value: 'LEADS', label: 'Leads' },
+    { value: 'TRAFFIC', label: 'Traffic' },
+    { value: 'AWARENESS', label: 'Awareness' },
+  ];
+
+  const renderObjective = (objective: { value: Goal; label: string }) => {
+    const active = p.goal === objective.value;
+    return (
+      <button
+        key={objective.value}
+        type="button"
+        className={`planner-pill${active ? ' is-active' : ''}`}
+        aria-pressed={active}
+        onClick={() => p.onGoalChange(objective.value)}
+      >
+        {objective.label}
+      </button>
+    );
+  };
+
   const platformChip = (platform: Platform) => {
     const active = p.selectedPlatforms.includes(platform);
     const label = PLATFORM_LABELS[platform] || platform;
     return (
       <button
         key={platform}
-        className={`mp-chip ${active ? "is-active" : ""}`}
+        type="button"
+        className={`planner-chip${active ? ' is-active' : ''}`}
+        aria-pressed={active}
         onClick={() => p.onPlatformToggle(platform)}
       >
         {label}
@@ -43,126 +77,133 @@ export default function MediaPlannerCard(p: Props){
   };
 
   return (
-    <section className="mp-card">
-      <header className="mp-card__header">
-        <h3 className="mp-title">Media Planner</h3>
-        {/* removed right badges to tighten header */}
-      </header>
+    <section className="planner-card" aria-labelledby={`${id}-card-title`}>
+      <div className="planner-tag" id={`${id}-card-title`}>
+        Media planner
+      </div>
+      <div className="planner-card__content">
+        <div>
+          <div className="planner-tag">Campaign inputs</div>
+          <label className="planner-field" htmlFor={budgetId}>
+            <span className="planner-label">Total budget</span>
+            <input
+              id={budgetId}
+              className="planner-input"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={100}
+              value={p.totalBudget}
+              onChange={(e) => p.onTotalBudgetChange(Number(e.target.value) || 0)}
+              placeholder="Enter media spend only"
+            />
+            <span className="planner-hint">Media spend only; excludes management/design fees.</span>
+          </label>
 
-      {/* Form grid */}
-      <div className="mp-grid">
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Total Budget</div>
-          <input
-            className="mp-input"
-            type="number"
-            value={p.totalBudget}
-            onChange={(e) => p.onTotalBudgetChange(Number(e.target.value) || 0)}
-            placeholder="Enter media spend only"
-            min="0"
-            step="100"
-          />
-          <div className="mp-hint">Media spend only; excludes management/design fees.</div>
+          <label className="planner-field" htmlFor={currencyId}>
+            <span className="planner-label">Currency</span>
+            <select
+              id={currencyId}
+              className="planner-select"
+              value={p.currency}
+              onChange={(e) => p.onCurrencyChange(e.target.value as Currency)}
+            >
+              <option value="EGP">EGP</option>
+              <option value="USD">USD</option>
+              <option value="AED">AED</option>
+              <option value="SAR">SAR</option>
+              <option value="EUR">EUR</option>
+            </select>
+          </label>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Currency</div>
-          <select
-            className="mp-select"
-            value={p.currency}
-            onChange={(e) => p.onCurrencyChange(e.target.value as Currency)}
-          >
-            <option value="EGP">EGP</option>
-            <option value="USD">USD</option>
-            <option value="AED">AED</option>
-            <option value="SAR">SAR</option>
-            <option value="EUR">EUR</option>
-          </select>
+        <div>
+          <div className="planner-tag">Targeting</div>
+          <label className="planner-field" htmlFor={marketId}>
+            <span className="planner-label">Market</span>
+            <select
+              id={marketId}
+              className="planner-select"
+              value={p.market}
+              onChange={(e) => p.onMarketChange(e.target.value as Market)}
+            >
+              <option value="Egypt">Egypt</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="UAE">UAE</option>
+              <option value="Europe">Europe</option>
+            </select>
+          </label>
+
+          <label className="planner-field" htmlFor={nicheId}>
+            <span className="planner-label">Niche</span>
+            <select
+              id={nicheId}
+              className="planner-select"
+              value={p.niche}
+              onChange={(e) => p.onNicheChange(e.target.value)}
+            >
+              {p.nicheOptions.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+            <span className="planner-hint">Auto-sets close rate & revenue per sale (editable).</span>
+          </label>
+
+          <label className="planner-field" htmlFor={leadSaleId}>
+            <span className="planner-label">Lead→Sale %</span>
+            <input
+              id={leadSaleId}
+              className="planner-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              max={100}
+              step={1}
+              value={p.leadToSale}
+              onChange={(e) => p.onLeadToSaleChange(Number(e.target.value) || 0)}
+            />
+          </label>
+
+          <label className="planner-field" htmlFor={revenueId}>
+            <span className="planner-label">Revenue per sale</span>
+            <input
+              id={revenueId}
+              className="planner-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step={50}
+              value={p.revenuePerSale}
+              onChange={(e) => p.onRevenuePerSaleChange(Number(e.target.value) || 0)}
+            />
+          </label>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Market</div>
-          <select
-            className="mp-select"
-            value={p.market}
-            onChange={(e) => p.onMarketChange(e.target.value as Market)}
-          >
-            <option value="Egypt">Egypt</option>
-            <option value="Saudi Arabia">Saudi Arabia</option>
-            <option value="UAE">UAE</option>
-            <option value="Europe">Europe</option>
-          </select>
+        <div>
+          <div className="planner-tag" id={goalLabelId}>Objective</div>
+          <div className="planner-objectives" role="group" aria-labelledby={goalLabelId}>
+            {objectives.map(renderObjective)}
+          </div>
+          <span className="planner-hint">Adjusts auto budget split unless manual % is on.</span>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Goal</div>
-          <select
-            className="mp-select"
-            value={p.goal}
-            onChange={(e) => p.onGoalChange(e.target.value as Goal)}
-          >
-            <option value="LEADS">Leads</option>
-            <option value="TRAFFIC">Traffic</option>
-            <option value="AWARENESS">Awareness</option>
-          </select>
-          <div className="mp-hint">Changes auto budget split unless manual % is on.</div>
+        <div>
+          <div className="planner-tag" id={platformsLabelId}>Platforms</div>
+          <div className="planner-chips" role="group" aria-labelledby={platformsLabelId}>
+            {p.platforms.map(platformChip)}
+          </div>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Niche</div>
-          <select
-            className="mp-select"
-            value={p.niche}
-            onChange={(e) => p.onNicheChange(e.target.value)}
-          >
-            {p.nicheOptions.map((option) => (
-              <option key={option} value={option}>{option}</option>
-            ))}
-          </select>
-          <div className="mp-hint">Auto-sets close-rate & revenue per sale (editable).</div>
-        </div>
-
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Lead→Sale %</div>
-          <input
-            className="mp-input" 
-            type="number" 
-            min={0} 
-            max={100}
-            value={p.leadToSale}
-            onChange={(e) => p.onLeadToSaleChange(Number(e.target.value) || 0)}
-            step="1"
-          />
-        </div>
-
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Revenue per Sale</div>
-          <input
-            className="mp-input" 
-            type="number" 
-            min={0}
-            value={p.revenuePerSale}
-            onChange={(e) => p.onRevenuePerSaleChange(Number(e.target.value) || 0)}
-            step="50"
+        <div>
+          <div className="planner-tag">Live preview</div>
+          <SplitControlsRow
+            mode={p.mode}
+            includeAll={p.includeAll}
+            onChangeMode={p.onModeChange}
+            onIncludeAllChange={p.onIncludeAllChange}
           />
         </div>
       </div>
-
-      {/* Platforms */}
-      <div className="mp-field" style={{marginTop:"20px"}}>
-        <div className="mp-label">Platforms</div>
-        <div className="mp-chips">
-          {p.platforms.map(platformChip)}
-        </div>
-      </div>
-
-      {/* Split Controls Row */}
-      <SplitControlsRow
-        mode={p.mode}
-        includeAll={p.includeAll}
-        onChangeMode={p.onModeChange}
-        onIncludeAllChange={p.onIncludeAllChange}
-      />
     </section>
   );
 }

--- a/src/components/SplitControlsRow.tsx
+++ b/src/components/SplitControlsRow.tsx
@@ -7,12 +7,6 @@ type Props = {
   onIncludeAllChange: (value: boolean) => void;
 };
 
-const chip = {
-  surface: { background: "#111315", border: "1px solid #27292B" },
-  inner:   { background: "#0E1011" },
-  textMut: { color: "#BDBDBD" },
-};
-
 export default function SplitControlsRow({
   mode,
   includeAll,
@@ -22,95 +16,47 @@ export default function SplitControlsRow({
   const toggleDisabled = mode !== "auto";
 
   return (
-    <div style={{ ...chip.surface, borderRadius: 16, padding: 12 }} data-testid="split-controls-row">
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
-        {/* Mode pill */}
-        <span
-          style={{
-            ...chip.inner,
-            border: "1px solid #27292B",
-            borderRadius: 999,
-            padding: "6px 12px",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 8,
-            fontSize: 14,
-          }}
-        >
-          <span style={{ width: 8, height: 8, borderRadius: 999, background: "#7C3AED" }} />
-          <span>Mode: {mode === "auto" ? "Auto" : "Manual"}</span>
+    <div className="planner-mode" data-testid="split-controls-row">
+      <div className="planner-mode__top">
+        <span className="planner-mode__chip">
+          <span className="planner-mode__chip-dot" />
+          Mode: {mode === "auto" ? "Auto" : "Manual"}
         </span>
-
-        {/* removed Include-all status pill */}
-
-        {/* removed Platforms count pill */}
-
-        {/* Segmented control */}
-        <div
-          style={{
-            marginLeft: "auto",
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-            flexWrap: "wrap",
-            justifyContent: "flex-end",
-          }}
-        >
-          <div style={{ ...chip.inner, border: "1px solid #27292B", borderRadius: 12, padding: 4, display: "flex" }}>
-            <button
-              onClick={() => onChangeMode("auto")}
-              style={{
-                padding: "6px 14px",
-                fontSize: 14,
-                borderRadius: 8,
-                background: mode === "auto" ? "#2C2C2C" : "transparent",
-                color: mode === "auto" ? "#FFFFFF" : "#BDBDBD",
-                transition: "background .15s ease, color .15s ease",
-                border: "none",
-                cursor: "pointer",
-              }}
-            >
-              Auto
-            </button>
-            <button
-              onClick={() => onChangeMode("manual")}
-              style={{
-                padding: "6px 14px",
-                fontSize: 14,
-                borderRadius: 8,
-                background: mode === "manual" ? "#2C2C2C" : "transparent",
-                color: mode === "manual" ? "#FFFFFF" : "#BDBDBD",
-                transition: "background .15s ease, color .15s ease",
-                border: "none",
-                cursor: "pointer",
-              }}
-            >
-              Manual
-            </button>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <label
-              className="switch"
-              title="Give every selected platform at least 10% of the budget in auto mode"
-              aria-label="Give every selected platform at least 10% of the budget in auto mode"
-              style={{
-                opacity: toggleDisabled ? 0.4 : 1,
-                pointerEvents: toggleDisabled ? "none" : "auto",
-                cursor: toggleDisabled ? "not-allowed" : "pointer",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={includeAll}
-                onChange={(e) => onIncludeAllChange(e.target.checked)}
-                disabled={toggleDisabled}
-              />
-              <span className="slider" />
-            </label>
-            <span style={{ fontSize: 13, color: "#BDBDBD" }}>
-              Min 10% each{toggleDisabled ? ' (auto only)' : ''}
+      </div>
+      <div className="planner-mode__row">
+        <div className="planner-seg" role="group" aria-label="Allocation mode">
+          <button
+            type="button"
+            className={mode === "auto" ? "is-active" : ""}
+            onClick={() => onChangeMode("auto")}
+          >
+            Auto
+          </button>
+          <button
+            type="button"
+            className={mode === "manual" ? "is-active" : ""}
+            onClick={() => onChangeMode("manual")}
+          >
+            Manual
+          </button>
+        </div>
+        <div className="planner-toggle">
+          <label
+            className={`planner-switch${toggleDisabled ? " is-disabled" : ""}`}
+            title="Give every selected platform at least 10% of the budget in auto mode"
+            aria-label="Give every selected platform at least 10% of the budget in auto mode"
+          >
+            <input
+              type="checkbox"
+              checked={includeAll}
+              onChange={(e) => onIncludeAllChange(e.target.checked)}
+              disabled={toggleDisabled}
+            />
+            <span className="planner-switch__track">
+              <span className="planner-switch__thumb" />
             </span>
-          </div>
+          </label>
+          <span>Min 10% each{toggleDisabled ? ' (auto only)' : ''}</span>
         </div>
       </div>
     </div>

--- a/src/components/ui/AnimatedCounter.tsx
+++ b/src/components/ui/AnimatedCounter.tsx
@@ -1,0 +1,36 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import { useMemo } from 'react';
+
+type AnimatedCounterProps = {
+  value: number | null | undefined;
+  formatter?: (value: number) => string;
+  fallback?: string;
+  className?: string;
+};
+
+export function AnimatedCounter({ value, formatter, fallback = '—', className }: AnimatedCounterProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const display = useMemo(() => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return fallback;
+    }
+    return formatter ? formatter(value) : new Intl.NumberFormat('en-US').format(value);
+  }, [value, formatter, fallback]);
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return <span className={className}>{display}</span>;
+  }
+
+  return (
+    <motion.span
+      key={`${display}-${value}`}
+      className={className}
+      initial={prefersReducedMotion ? { opacity: 0.7 } : { scale: 0.96, opacity: 0.7 }}
+      animate={prefersReducedMotion ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+      transition={{ duration: 0.32, ease: [0.16, 1, 0.3, 1] }}
+    >
+      {display}
+    </motion.span>
+  );
+}

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -116,113 +116,23 @@
 }
 
 :root{
-  --bg-elev-1:#151821;
-  --bg-elev-2:#171a23;
-  --card:#17191f;
-  --card-2:#14161d;
-  --text:#fff;
-  --muted:#A8B1C0;
-  --line:#252832;
-  --focus:#7C4DFF;            /* Deep purple accent used across app */
-  --chip:#6D28D9;
-  --chip-weak:#3B2B5F;
-  --success:#1DB954;
-  --danger:#EF4444;
-  --radius:16px;
-  --space-1:8px; --space-2:12px; --space-3:16px; --space-4:20px; --space-5:28px;
-  --field-h:44px; --field-px:12px;
-  --shadow:0 10px 24px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.02);
+  --bg-elev-1:rgba(255,255,255,0.02);
+  --bg-elev-2:rgba(255,255,255,0.05);
+  --card:linear-gradient(180deg, rgba(22,30,45,0.88), rgba(12,18,30,0.94));
+  --card-2:rgba(9,14,22,0.92);
+  --text:var(--fg);
+  --muted:rgba(255,255,255,0.60);
+  --line:rgba(255,255,255,0.08);
+  --focus:#3E8BFF;
+  --chip:var(--ac-1);
+  --chip-weak:rgba(62,139,255,0.08);
+  --success:#32D583;
+  --danger:#F97066;
+  --radius:24px;
+  --space-1:8px; --space-2:12px; --space-3:16px; --space-4:24px; --space-5:32px;
+  --field-h:48px; --field-px:16px;
+  --shadow:0 8px 32px rgba(0,0,0,0.45);
 }
-
-.mp-card{
-  background:var(--card);
-  border:1px solid var(--line);
-  border-radius:var(--radius);
-  padding:var(--space-5);
-  box-shadow:var(--shadow);
-  color:var(--text);
-}
-.mp-card__header{
-  display:flex; align-items:center; justify-content:space-between;
-  margin-bottom:var(--space-4);
-}
-.mp-title{font-weight:700; letter-spacing:.2px; font-size:20px;}
-.mp-badges{display:flex; gap:8px; flex-wrap:wrap}
-
-.mp-grid{
-  display:grid;
-  gap:var(--space-4);
-  grid-template-columns:repeat(12,1fr);
-}
-.mp-col-6{grid-column:span 6}
-@media (max-width: 960px){ .mp-col-6{grid-column:span 12} }
-
-.mp-field{display:flex; flex-direction:column; gap:6px;}
-.mp-label{
-  font-size:12px; letter-spacing:.4px; text-transform:uppercase;
-  color:#cdd5e0;
-}
-.mp-hint{font-size:12px; color:var(--muted)}
-.mp-input, .mp-select{
-  height:var(--field-h);
-  border-radius:12px;
-  border:1px solid var(--line);
-  background:var(--card-2);
-  color:var(--text);
-  padding:0 var(--field-px);
-  outline:none;
-}
-.mp-input:focus, .mp-select:focus{
-  border-color:var(--focus);
-  box-shadow:0 0 0 3px rgba(124,77,255,.25);
-}
-
-/* Platform chips */
-.mp-chips{display:flex; gap:8px; flex-wrap:wrap}
-.mp-chip{
-  background:var(--chip-weak);
-  color:#E9D5FF;
-  border:1px solid #4b3a7a;
-  height:32px; padding:0 12px; border-radius:20px;
-  font-weight:600; font-size:12px;
-  display:inline-flex; align-items:center; gap:8px;
-  transition:transform .15s ease, background .2s ease, border .2s ease;
-}
-.mp-chip:hover{transform:translateY(-1px)}
-.mp-chip.is-active{
-  background:var(--focus);
-  border-color:var(--focus);
-  color:#fff;
-}
-
-/* Segmented control (Auto / Manual) */
-.mp-seg{
-  display:inline-flex; background:#0f1117; border:1px solid var(--line); border-radius:12px;
-  padding:4px; gap:4px;
-}
-.mp-seg button{
-  min-width:88px; height:34px; border-radius:8px; border:none; cursor:pointer;
-  color:#cfd6e2; background:transparent; font-weight:600;
-}
-.mp-seg button.is-active{background:var(--focus); color:#fff}
-
-/* Modern switch */
-.mp-switch{display:flex; align-items:center; gap:12px}
-.mp-switch input[type="checkbox"]{display:none}
-.mp-switch .track{
-  width:44px; height:24px; border-radius:999px; background:#2a2f3a; position:relative; border:1px solid var(--line);
-}
-.mp-switch .thumb{
-  width:18px; height:18px; border-radius:50%; background:#cfd6e2;
-  position:absolute; top:2px; left:2px; transition:all .18s ease;
-  box-shadow:0 2px 6px rgba(0,0,0,.35)
-}
-.mp-switch input:checked + .track{background:var(--focus); border-color:var(--focus)}
-.mp-switch input:checked + .track .thumb{left:calc(100% - 20px); background:#fff}
-
-/* Inline meta row */
-.mp-meta{display:flex; gap:10px; flex-wrap:wrap; margin-top:4px}
-.mp-dot{width:6px; height:6px; border-radius:50%; background:#667085; display:inline-block; margin-right:6px}
 
 /* Optional: selected bar label chip */
 .chart-chip {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,20 +1,50 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 :root{
-  --bg:#121212; --fg:#FFFFFF; --muted:#BDBDBD; --primary:#673AB7; --accent:#FF4081;
-  --inputBg:#1d1d1f; --border:#2b2b2e;
-  --surface1:#1a1a1c; --surface2:#202023;
-  --radius:20px; --radius-sm:12px; --ring:rgba(103,58,183,.35);
-  --shadow:0 12px 36px rgba(0,0,0,.40), 0 1px 0 rgba(255,255,255,.02) inset;
+  --bg:#060a11;
+  --fg:rgba(231,236,243,0.90);
+  --muted:rgba(255,255,255,0.60);
+  --fg-strong:#FFFFFF;
+  --primary:#3E8BFF;
+  --accent:#6B70FF;
+  --inputBg:rgba(255,255,255,0.04);
+  --border:rgba(255,255,255,0.06);
+  --surface1:rgba(255,255,255,0.03);
+  --surface2:rgba(255,255,255,0.06);
+  --radius:24px;
+  --radius-sm:16px;
+  --ring:rgba(62,139,255,0.35);
+  --shadow:0 8px 32px rgba(0,0,0,0.45);
+  --inner-highlight:0 1px 0 rgba(255,255,255,0.04) inset;
+  --ac-1:#3E8BFF;
+  --ac-2:#6B70FF;
 }
 html,body,#root{height:100%}
-body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--fg);
+  font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+}
 
 /* App bar (sticky, blurred) */
 .appbar{position:sticky;top:0;z-index:20;background:linear-gradient(180deg, rgba(18,18,18,.9), rgba(18,18,18,.6));backdrop-filter:blur(8px)}
 
 /* Cards & sections */
-.card{background:linear-gradient(180deg,var(--surface2),var(--surface1));border:1px solid var(--border);
-      border-radius:var(--radius);box-shadow:var(--shadow)}
+.card{
+  position:relative;
+  background:linear-gradient(180deg, rgba(24,31,46,0.86), rgba(12,18,28,0.92));
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+}
+.card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  box-shadow:var(--inner-highlight);
+  pointer-events:none;
+}
 .h1{font-size:28px;font-weight:800;letter-spacing:-.2px}
 .h2{font-size:12px;font-weight:700;color:var(--muted);letter-spacing:.4px}
 
@@ -66,15 +96,6 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 .chip:hover{transform:translateY(-1px);background:#2a2a2f}
 .chip[aria-pressed="true"]{background:var(--primary);color:#fff;border-color:#6c39d8}
 
-/* KPI group (FIX for broken corners / harsh lines) */
-.kpiGroup{border-radius:var(--radius);background:var(--border);padding:1px;box-shadow:var(--shadow)}
-.kpiGrid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border);
-  border-radius:calc(var(--radius) - 1px);overflow:hidden}
-@media (min-width:768px){.kpiGrid{grid-template-columns:repeat(4,1fr)}}
-.kpiCell{background:var(--surface1);padding:16px 18px}
-.kpiLabel{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px}
-.kpiValue{margin-top:4px;font-size:24px;font-weight:700;letter-spacing:-.2px;font-variant-numeric:tabular-nums}
-
 /* Table (pill rows) */
 .tableWrap{overflow:auto;border-radius:var(--radius)}
 .table{width:100%;border-collapse:separate;border-spacing:0 8px}
@@ -99,12 +120,474 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 /* ==== PREMIUM APP BACKGROUND & TYPOGRAPHY ==== */
 .appBg{
   position:relative;
+  min-height:100vh;
   background:
-    radial-gradient(1200px 800px at 10% -20%, rgba(103,58,183,.18), transparent 55%),
-    radial-gradient(900px 600px at 90% 120%, rgba(255,64,129,.12), transparent 55%),
-    linear-gradient(180deg, #0F1012 0%, #0F1012 100%);
+    radial-gradient(1200px 900px at -10% -20%, rgba(62,139,255,0.20), transparent 65%),
+    radial-gradient(1000px 800px at 120% 130%, rgba(107,112,255,0.18), transparent 65%),
+    linear-gradient(to bottom, rgba(16,22,30,0.55), rgba(10,14,20,0.55));
 }
-.appBg::after{content:"";position:fixed;inset:0;pointer-events:none;background:radial-gradient(1200px 800px at 50% -20%, rgba(255,255,255,.06), transparent 60%);mix-blend-mode:overlay;opacity:.35}
+.appBg::after{
+  content:"";
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  background:
+    radial-gradient(1000px 700px at 50% -10%, rgba(255,255,255,0.08), transparent 65%);
+  mix-blend-mode:overlay;
+  opacity:.32;
+  transition:opacity .35s ease;
+}
+body.planner-in .appBg::after{opacity:.18}
+
+/* ==== Planner Hero & Layout ==== */
+.planner-shell{
+  padding-block:clamp(36px,8vw,96px);
+}
+
+.planner-grid{
+  max-width:1200px;
+  margin:0 auto;
+  padding-inline:clamp(24px,4vw,32px);
+  display:grid;
+  gap:clamp(32px,5vw,48px);
+}
+
+.planner-card-wrap,
+.planner-copy{
+  display:flex;
+  flex-direction:column;
+  gap:clamp(16px,3vw,24px);
+}
+
+.planner-card{
+  position:relative;
+  background:linear-gradient(180deg, rgba(22,30,45,0.92), rgba(9,13,22,0.96));
+  border:1px solid var(--border);
+  border-radius:32px;
+  padding:clamp(24px,3vw,32px);
+  color:var(--fg);
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(18px);
+}
+
+.planner-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  box-shadow:var(--inner-highlight);
+  pointer-events:none;
+}
+
+.planner-card__content{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.planner-tag{
+  font-size:12px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.24em;
+  color:rgba(255,255,255,0.48);
+  margin-bottom:6px;
+}
+
+.planner-field{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.planner-label{
+  font-size:12px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.24em;
+  color:var(--muted);
+}
+
+.planner-hint{
+  font-size:12px;
+  color:rgba(231,236,243,0.55);
+}
+
+.planner-input,
+.planner-select{
+  height:var(--field-h);
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.05);
+  background:var(--inputBg);
+  color:var(--fg);
+  padding:0 var(--field-px);
+  font-size:15px;
+  font-weight:500;
+  letter-spacing:.01em;
+  transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.planner-input::placeholder{color:rgba(231,236,243,0.45)}
+
+.planner-input:focus,
+.planner-select:focus{
+  outline:none;
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(62,139,255,0.55);
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-select{
+  appearance:none;
+  background-image:linear-gradient(45deg, transparent 50%, rgba(231,236,243,0.7) 50%),
+    linear-gradient(135deg, rgba(231,236,243,0.7) 50%, transparent 50%);
+  background-position:calc(100% - 22px) calc(50% - 3px), calc(100% - 16px) calc(50% - 3px);
+  background-size:6px 6px, 6px 6px;
+  background-repeat:no-repeat;
+  padding-right:48px;
+}
+
+.planner-select option{
+  background:#0b1019;
+  color:var(--fg-strong);
+}
+
+.planner-objectives,
+.planner-chips{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.planner-pill,
+.planner-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.05);
+  background:rgba(255,255,255,0.04);
+  color:rgba(231,236,243,0.88);
+  font-size:14px;
+  font-weight:600;
+  letter-spacing:.01em;
+  transition:transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
+  cursor:pointer;
+}
+
+.planner-pill:hover,
+.planner-chip:hover{
+  box-shadow:inset 0 0 0 1px rgba(114,137,218,0.25);
+}
+
+.planner-pill.is-active,
+.planner-chip.is-active{
+  color:#fff;
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  border-color:transparent;
+  box-shadow:inset 0 0 18px rgba(114,137,218,0.4), 0 10px 28px rgba(8,12,20,0.45);
+}
+
+.planner-pill:focus-visible,
+.planner-chip:focus-visible,
+.planner-btn:focus-visible,
+.planner-input:focus-visible,
+.planner-select:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-mode{
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:24px;
+  padding:18px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.planner-mode__top{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  align-items:center;
+}
+
+.planner-mode__chip{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  color:rgba(231,236,243,0.88);
+  font-size:13px;
+  font-weight:600;
+}
+
+.planner-mode__chip-dot{
+  width:8px;
+  height:8px;
+  border-radius:999px;
+  background:var(--ac-1);
+  box-shadow:0 0 12px rgba(62,139,255,0.45);
+}
+
+.planner-mode__row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:center;
+  justify-content:space-between;
+}
+
+.planner-seg{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:4px;
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,0.05);
+  background:rgba(255,255,255,0.04);
+}
+
+.planner-seg button{
+  min-width:96px;
+  height:36px;
+  border-radius:12px;
+  border:none;
+  background:transparent;
+  color:rgba(231,236,243,0.7);
+  font-weight:600;
+  letter-spacing:.01em;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease, box-shadow .2s ease;
+}
+
+.planner-seg button.is-active{
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  color:#fff;
+  box-shadow:inset 0 0 14px rgba(114,137,218,0.42);
+}
+
+.planner-seg button:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-toggle{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  color:rgba(231,236,243,0.72);
+  font-size:13px;
+}
+
+.planner-switch{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  width:52px;
+  height:28px;
+  cursor:pointer;
+}
+
+.planner-switch input{opacity:0;width:0;height:0}
+
+.planner-switch__track{
+  position:absolute;
+  inset:0;
+  border-radius:999px;
+  background:rgba(255,255,255,0.05);
+  border:1px solid rgba(255,255,255,0.08);
+  transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.planner-switch__thumb{
+  position:absolute;
+  top:50%;
+  left:6px;
+  width:20px;
+  height:20px;
+  border-radius:999px;
+  background:#ECF3FF;
+  transform:translate(0,-50%);
+  box-shadow:0 6px 18px rgba(8,12,20,0.45);
+  transition:transform .22s cubic-bezier(.4,0,.2,1), background .2s ease;
+}
+
+.planner-switch input:checked + .planner-switch__track{
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  border-color:rgba(62,139,255,0.65);
+  box-shadow:0 0 12px rgba(62,139,255,0.35);
+}
+
+.planner-switch input:checked + .planner-switch__track .planner-switch__thumb{
+  transform:translate(22px,-50%);
+  background:#fff;
+}
+
+.planner-switch:focus-within .planner-switch__track{
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-switch.is-disabled{
+  opacity:0.4;
+  cursor:not-allowed;
+}
+
+.planner-eyebrow{
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  color:rgba(255,255,255,0.45);
+}
+
+.planner-heading{
+  margin:0;
+  font-weight:800;
+  font-size:clamp(28px,4vw,72px);
+  line-height:1.05;
+  color:var(--fg-strong);
+}
+
+.planner-subcopy{
+  font-size:clamp(16px,1.2vw,20px);
+  color:rgba(231,236,243,0.82);
+  max-width:42ch;
+}
+
+.planner-note{
+  font-size:14px;
+  color:rgba(255,255,255,0.4);
+  max-width:48ch;
+}
+
+.planner-cta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:center;
+}
+
+.planner-btn{
+  border:none;
+  outline:none;
+  cursor:pointer;
+  font:inherit;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  font-weight:600;
+  letter-spacing:.02em;
+  transition:transform .2s ease, box-shadow .2s ease, filter .2s ease;
+}
+
+.planner-btn-primary{
+  flex:1 1 240px;
+  height:48px;
+  border-radius:999px;
+  background:linear-gradient(180deg,#0D1C2A,#152A43);
+  color:#ECF3FF;
+  box-shadow:inset 0 1px 0 rgba(236,243,255,0.16), 0 16px 42px rgba(5,12,24,0.45);
+  border:1px solid rgba(62,139,255,0.25);
+}
+
+.planner-btn-primary:hover{
+  filter:brightness(1.05);
+}
+
+.planner-btn-primary:active{
+  transform:scale(.98);
+  box-shadow:inset 0 1px 0 rgba(236,243,255,0.12), 0 8px 24px rgba(5,12,24,0.45);
+}
+
+.planner-link{
+  color:rgba(255,255,255,0.5);
+  text-decoration:none;
+  font-weight:600;
+  transition:color .2s ease;
+}
+
+.planner-link:hover{color:rgba(255,255,255,0.8)}
+
+.planner-link:focus-visible{
+  outline:none;
+  box-shadow:0 1px 0 rgba(255,255,255,0.55);
+}
+
+@media (max-width:1023px){
+  .planner-card-wrap{order:1}
+  .planner-copy{order:2}
+  .planner-cta{flex-direction:column;align-items:stretch;gap:8px}
+  .planner-btn-primary{flex:1 1 auto;width:100%}
+}
+
+@media (min-width:1024px){
+  .planner-grid{grid-template-columns:repeat(12,minmax(0,1fr));align-items:start}
+  .planner-card-wrap{grid-column:span 7;order:2}
+  .planner-copy{grid-column:span 5;order:1}
+}
+
+/* ==== KPI Summary ==== */
+.kpi-panel{
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:28px;
+  padding:24px;
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(14px);
+}
+
+.kpi-panel .planner-tag{margin-bottom:14px;color:rgba(255,255,255,0.5)}
+
+.kpi-list{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+
+.kpi-row{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:16px 20px;
+  border-radius:20px;
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.04);
+  backdrop-filter:blur(6px);
+}
+
+.kpi-label{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  font-size:13px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.18em;
+  color:rgba(231,236,243,0.68);
+}
+
+.kpi-dot{
+  width:10px;
+  height:10px;
+  border-radius:999px;
+  box-shadow:0 0 0 4px rgba(255,255,255,0.04);
+}
+
+.kpi-dot--accent{background:linear-gradient(135deg,var(--ac-1),var(--ac-2))}
+.kpi-dot--reach{background:#4ade80}
+.kpi-dot--efficiency{background:#60a5fa}
+.kpi-dot--confidence{background:#c084fc}
+
+.kpi-value{
+  font-size:28px;
+  font-weight:700;
+  color:var(--fg-strong);
+  font-variant-numeric:tabular-nums;
+}
 
 /* ==== GLOBAL RHYTHM ==== */
 .container{max-width:1160px;margin-inline:auto;padding-inline:16px}
@@ -159,12 +642,13 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 .comfy .table tbody td{padding:14px 12px}
 
 /* --- Cell visuals --- */
-.badgeTiny{font-size:11px;color:#BDBDBD;padding:2px 6px;border:1px solid var(--border);border-radius:999px}
+.badgeTiny{font-size:11px;color:rgba(231,236,243,0.72);padding:2px 6px;border:1px solid var(--border);border-radius:999px}
 .progressCell{display:flex;align-items:center;gap:8px}
-.progressBar{flex:1;height:6px;background:#25262b;border-radius:999px;overflow:hidden}
-.progressInner{height:100%;background:linear-gradient(90deg,#5B8CFF,#7F55E0);border-radius:999px}
-.warn{background:rgba(255,180,90,.08)}
-.good{background:rgba(139,209,124,.08)}
+.progressBar{flex:1;height:8px;background:rgba(255,255,255,0.1);border-radius:999px;overflow:hidden;position:relative}
+.progressInner{height:100%;background:linear-gradient(90deg,rgba(62,139,255,0.6),rgba(107,112,255,0.6));border-radius:inherit;transition:width .42s cubic-bezier(.23,1,.32,1),filter .2s ease}
+.progressBar:hover .progressInner{filter:brightness(1.06)}
+.warn{background:rgba(249,112,102,0.08)}
+.good{background:rgba(50,213,131,0.08)}
 
 /* ---- Header chips (replace white badges) ---- */
 .thChip{


### PR DESCRIPTION
## Summary
- replace the planner hero with the new motion-enabled layout that wires up body state, scroll helpers, and CTA buttons
- reorganize the results and advanced planner sections so charts, tables, and recommendations sit inside the new containers
- refresh the KPI summary into the translucent panel styling backed by the AnimatedCounter component

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in legacy files)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cc53e4d3e483219fac52f34e16db6f