### PR TITLE
Polish planner surfaces to match the new palette

### DIFF
--- a/src/components/ColumnsDialog.tsx
+++ b/src/components/ColumnsDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import AppCard from "../ui/AppCard";
 
 export type ColumnDef = { key: string; label: string; visible: boolean };
 
@@ -73,39 +74,45 @@ export default function ColumnsDialog({
   if (!open) return null;
 
   return (
-    <div style={{
-      position:"fixed", inset:0, background:"rgba(0,0,0,.5)", zIndex:50,
-      display:"flex", alignItems:"center", justifyContent:"center"
-    }} onClick={onClose}>
-      <div
-        className="app-card"
-        style={{ width: 420, padding:16, background: "var(--card-bg)" }}
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(6, 10, 17, 0.72)",
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+      }}
+      onClick={onClose}
+    >
+      <AppCard
+        className="columns-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Select columns to display"
         onClick={(e) => e.stopPropagation()}
       >
-        <div style={{ fontWeight:700, marginBottom:8, color: "var(--text)" }}>Columns</div>
-        <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:8 }}>
+        <div className="app-card__header">
+          <span className="app-card__eyebrow">Columns</span>
+          <span className="app-card__subtitle">Choose which metrics appear in the channel breakdown.</span>
+        </div>
+        <div className="columns-grid">
           {cols.map(c => (
-            <label key={c.key} className="app-card--inner" style={{ 
-              padding:8, 
-              display:"flex", 
-              alignItems:"center", 
-              gap:8,
-              cursor: "pointer"
-            }}>
-              <input 
-                type="checkbox" 
-                checked={c.visible} 
+            <label key={c.key} className="columns-option">
+              <input
+                type="checkbox"
+                checked={c.visible}
                 onChange={() => toggle(c.key)}
-                style={{ accentColor: "var(--accent)" }}
               />
-              <span style={{ color:"var(--text)" }}>{c.label}</span>
+              <span>{c.label}</span>
             </label>
           ))}
         </div>
-        <div style={{ display:"flex", justifyContent:"flex-end", marginTop:12 }}>
+        <div className="columns-footer">
           <button className="columns-btn" onClick={onClose}>Done</button>
         </div>
-      </div>
+      </AppCard>
     </div>
   );
 }

--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import type { Platform, Goal, Market, Currency } from '../lib/assumptions';
 import { PLATFORM_LABELS } from '../lib/utils';
 import SplitControlsRow from './SplitControlsRow';
@@ -28,13 +29,46 @@ type Props = {
 };
 
 export default function MediaPlannerCard(p: Props){
+  const id = useId();
+  const budgetId = `${id}-budget`;
+  const currencyId = `${id}-currency`;
+  const marketId = `${id}-market`;
+  const nicheId = `${id}-niche`;
+  const leadSaleId = `${id}-lead-sale`;
+  const revenueId = `${id}-revenue`;
+  const goalLabelId = `${id}-goal`;
+  const platformsLabelId = `${id}-platforms`;
+
+  const objectives: { value: Goal; label: string }[] = [
+    { value: 'LEADS', label: 'Leads' },
+    { value: 'TRAFFIC', label: 'Traffic' },
+    { value: 'AWARENESS', label: 'Awareness' },
+  ];
+
+  const renderObjective = (objective: { value: Goal; label: string }) => {
+    const active = p.goal === objective.value;
+    return (
+      <button
+        key={objective.value}
+        type="button"
+        className={`planner-pill${active ? ' is-active' : ''}`}
+        aria-pressed={active}
+        onClick={() => p.onGoalChange(objective.value)}
+      >
+        {objective.label}
+      </button>
+    );
+  };
+
   const platformChip = (platform: Platform) => {
     const active = p.selectedPlatforms.includes(platform);
     const label = PLATFORM_LABELS[platform] || platform;
     return (
       <button
         key={platform}
-        className={`mp-chip ${active ? "is-active" : ""}`}
+        type="button"
+        className={`planner-chip${active ? ' is-active' : ''}`}
+        aria-pressed={active}
         onClick={() => p.onPlatformToggle(platform)}
       >
         {label}
@@ -43,126 +77,133 @@ export default function MediaPlannerCard(p: Props){
   };
 
   return (
-    <section className="mp-card">
-      <header className="mp-card__header">
-        <h3 className="mp-title">Media Planner</h3>
-        {/* removed right badges to tighten header */}
-      </header>
+    <section className="planner-card" aria-labelledby={`${id}-card-title`}>
+      <div className="planner-tag" id={`${id}-card-title`}>
+        Media planner
+      </div>
+      <div className="planner-card__content">
+        <div>
+          <div className="planner-tag">Campaign inputs</div>
+          <label className="planner-field" htmlFor={budgetId}>
+            <span className="planner-label">Total budget</span>
+            <input
+              id={budgetId}
+              className="planner-input"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={100}
+              value={p.totalBudget}
+              onChange={(e) => p.onTotalBudgetChange(Number(e.target.value) || 0)}
+              placeholder="Enter media spend only"
+            />
+            <span className="planner-hint">Media spend only; excludes management/design fees.</span>
+          </label>
 
-      {/* Form grid */}
-      <div className="mp-grid">
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Total Budget</div>
-          <input
-            className="mp-input"
-            type="number"
-            value={p.totalBudget}
-            onChange={(e) => p.onTotalBudgetChange(Number(e.target.value) || 0)}
-            placeholder="Enter media spend only"
-            min="0"
-            step="100"
-          />
-          <div className="mp-hint">Media spend only; excludes management/design fees.</div>
+          <label className="planner-field" htmlFor={currencyId}>
+            <span className="planner-label">Currency</span>
+            <select
+              id={currencyId}
+              className="planner-select"
+              value={p.currency}
+              onChange={(e) => p.onCurrencyChange(e.target.value as Currency)}
+            >
+              <option value="EGP">EGP</option>
+              <option value="USD">USD</option>
+              <option value="AED">AED</option>
+              <option value="SAR">SAR</option>
+              <option value="EUR">EUR</option>
+            </select>
+          </label>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Currency</div>
-          <select
-            className="mp-select"
-            value={p.currency}
-            onChange={(e) => p.onCurrencyChange(e.target.value as Currency)}
-          >
-            <option value="EGP">EGP</option>
-            <option value="USD">USD</option>
-            <option value="AED">AED</option>
-            <option value="SAR">SAR</option>
-            <option value="EUR">EUR</option>
-          </select>
+        <div>
+          <div className="planner-tag">Targeting</div>
+          <label className="planner-field" htmlFor={marketId}>
+            <span className="planner-label">Market</span>
+            <select
+              id={marketId}
+              className="planner-select"
+              value={p.market}
+              onChange={(e) => p.onMarketChange(e.target.value as Market)}
+            >
+              <option value="Egypt">Egypt</option>
+              <option value="Saudi Arabia">Saudi Arabia</option>
+              <option value="UAE">UAE</option>
+              <option value="Europe">Europe</option>
+            </select>
+          </label>
+
+          <label className="planner-field" htmlFor={nicheId}>
+            <span className="planner-label">Niche</span>
+            <select
+              id={nicheId}
+              className="planner-select"
+              value={p.niche}
+              onChange={(e) => p.onNicheChange(e.target.value)}
+            >
+              {p.nicheOptions.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+            <span className="planner-hint">Auto-sets close rate & revenue per sale (editable).</span>
+          </label>
+
+          <label className="planner-field" htmlFor={leadSaleId}>
+            <span className="planner-label">Lead→Sale %</span>
+            <input
+              id={leadSaleId}
+              className="planner-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              max={100}
+              step={1}
+              value={p.leadToSale}
+              onChange={(e) => p.onLeadToSaleChange(Number(e.target.value) || 0)}
+            />
+          </label>
+
+          <label className="planner-field" htmlFor={revenueId}>
+            <span className="planner-label">Revenue per sale</span>
+            <input
+              id={revenueId}
+              className="planner-input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step={50}
+              value={p.revenuePerSale}
+              onChange={(e) => p.onRevenuePerSaleChange(Number(e.target.value) || 0)}
+            />
+          </label>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Market</div>
-          <select
-            className="mp-select"
-            value={p.market}
-            onChange={(e) => p.onMarketChange(e.target.value as Market)}
-          >
-            <option value="Egypt">Egypt</option>
-            <option value="Saudi Arabia">Saudi Arabia</option>
-            <option value="UAE">UAE</option>
-            <option value="Europe">Europe</option>
-          </select>
+        <div>
+          <div className="planner-tag" id={goalLabelId}>Objective</div>
+          <div className="planner-objectives" role="group" aria-labelledby={goalLabelId}>
+            {objectives.map(renderObjective)}
+          </div>
+          <span className="planner-hint">Adjusts auto budget split unless manual % is on.</span>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Goal</div>
-          <select
-            className="mp-select"
-            value={p.goal}
-            onChange={(e) => p.onGoalChange(e.target.value as Goal)}
-          >
-            <option value="LEADS">Leads</option>
-            <option value="TRAFFIC">Traffic</option>
-            <option value="AWARENESS">Awareness</option>
-          </select>
-          <div className="mp-hint">Changes auto budget split unless manual % is on.</div>
+        <div>
+          <div className="planner-tag" id={platformsLabelId}>Platforms</div>
+          <div className="planner-chips" role="group" aria-labelledby={platformsLabelId}>
+            {p.platforms.map(platformChip)}
+          </div>
         </div>
 
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Niche</div>
-          <select
-            className="mp-select"
-            value={p.niche}
-            onChange={(e) => p.onNicheChange(e.target.value)}
-          >
-            {p.nicheOptions.map((option) => (
-              <option key={option} value={option}>{option}</option>
-            ))}
-          </select>
-          <div className="mp-hint">Auto-sets close-rate & revenue per sale (editable).</div>
-        </div>
-
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Lead→Sale %</div>
-          <input
-            className="mp-input" 
-            type="number" 
-            min={0} 
-            max={100}
-            value={p.leadToSale}
-            onChange={(e) => p.onLeadToSaleChange(Number(e.target.value) || 0)}
-            step="1"
-          />
-        </div>
-
-        <div className="mp-field mp-col-6">
-          <div className="mp-label">Revenue per Sale</div>
-          <input
-            className="mp-input" 
-            type="number" 
-            min={0}
-            value={p.revenuePerSale}
-            onChange={(e) => p.onRevenuePerSaleChange(Number(e.target.value) || 0)}
-            step="50"
+        <div>
+          <div className="planner-tag">Live preview</div>
+          <SplitControlsRow
+            mode={p.mode}
+            includeAll={p.includeAll}
+            onChangeMode={p.onModeChange}
+            onIncludeAllChange={p.onIncludeAllChange}
           />
         </div>
       </div>
-
-      {/* Platforms */}
-      <div className="mp-field" style={{marginTop:"20px"}}>
-        <div className="mp-label">Platforms</div>
-        <div className="mp-chips">
-          {p.platforms.map(platformChip)}
-        </div>
-      </div>
-
-      {/* Split Controls Row */}
-      <SplitControlsRow
-        mode={p.mode}
-        includeAll={p.includeAll}
-        onChangeMode={p.onModeChange}
-        onIncludeAllChange={p.onIncludeAllChange}
-      />
     </section>
   );
 }

--- a/src/components/RecommendationsCard.tsx
+++ b/src/components/RecommendationsCard.tsx
@@ -3,14 +3,14 @@ import AppCard from "../ui/AppCard";
 export default function RecommendationsCard({ items }: { items: string[] }) {
   return (
     <AppCard className="mt-4">
-      <div style={{ padding:"12px 12px 4px", borderBottom:"1px solid var(--card-border)" }}>
-        <div style={{ fontWeight:700, letterSpacing:.2, color: "var(--text)" }}>RECOMMENDATIONS</div>
+      <div className="app-card__header">
+        <span className="app-card__eyebrow">Recommendations</span>
       </div>
-      <div className="app-card--inner" style={{ margin:12, padding:12 }}>
-        <ul style={{ display:"grid", gap:8 }}>
+      <div className="app-card--inner">
+        <ul className="recommendations-list">
           {items.map((t, i) => (
-            <li key={i} style={{ display:"flex", alignItems:"flex-start", gap:8, color:"var(--muted)", lineHeight:1.5 }}>
-              <span className="app-dot" style={{ marginTop:6 }} />
+            <li key={i} className="recommendations-item">
+              <span className="app-dot" />
               <span>{t}</span>
             </li>
           ))}

--- a/src/components/ResultsByPlatformCard.tsx
+++ b/src/components/ResultsByPlatformCard.tsx
@@ -55,10 +55,22 @@ export default function ResultsByPlatformCard({
     <AppCard className="mt-6">
       {showInlineKpis && (
         <div className="kpi-row">
-          <div className="kpi-tile"><div className="kpi-label">💰 Total Budget</div><div className="kpi-value">{totals.budget ?? "—"}</div></div>
-          <div className="kpi-tile"><div className="kpi-label">👆 Total Clicks</div><div className="kpi-value">{totals.clicks ?? "—"}</div></div>
-          <div className="kpi-tile"><div className="kpi-label">🎯 Total Leads</div><div className="kpi-value">{totals.leads ?? "—"}</div></div>
-          <div className="kpi-tile"><div className="kpi-label">📈 ROAS</div><div className="kpi-value">{(totals as any).roas ?? "—"}</div></div>
+          <div className="kpi-tile">
+            <div className="kpi-label">Total Budget</div>
+            <div className="kpi-value">{totals.budget ?? "—"}</div>
+          </div>
+          <div className="kpi-tile">
+            <div className="kpi-label">Total Clicks</div>
+            <div className="kpi-value">{totals.clicks ?? "—"}</div>
+          </div>
+          <div className="kpi-tile">
+            <div className="kpi-label">Total Leads</div>
+            <div className="kpi-value">{totals.leads ?? "—"}</div>
+          </div>
+          <div className="kpi-tile">
+            <div className="kpi-label">ROAS</div>
+            <div className="kpi-value">{(totals as any).roas ?? "—"}</div>
+          </div>
         </div>
       )}
 
@@ -70,27 +82,35 @@ export default function ResultsByPlatformCard({
       </div>
 
       <div className="table-wrap">
-        <table style={{ width: "100%", borderCollapse: "separate", borderSpacing: 0 }}>
+        <table className="app-table">
           <thead className="table-head">
             <tr>
-              <th>Platform</th>
-              {activeCols.map(c => (<th key={c.key}>{c.label}</th>))}
+              <th className="text-left">Platform</th>
+              {activeCols.map(c => (
+                <th key={c.key} className={c.key === "name" ? "text-left" : "text-right"}>{c.label}</th>
+              ))}
             </tr>
           </thead>
           <tbody>
             {filtered.map((r, i) => (
               <tr key={(r.name || r.platform || "") + i} className="table-row">
-                <td><span className="app-chip" style={{ background:"#1A1C1E" }}>{r.name || r.platform}</span></td>
+                <td className="text-left">
+                  <span className="app-chip">{r.name || r.platform}</span>
+                </td>
                 {activeCols.map(c => (
-                  <td key={c.key}>
+                  <td key={c.key} className={c.key === "name" ? "text-left" : "text-right"}>
                     {c.key === "budget" ? <span className="table-badge">{(r as any)[c.key]}</span> : (r as any)[c.key] ?? "—"}
                   </td>
                 ))}
               </tr>
             ))}
-            <tr className="table-row" style={{ background: "rgba(255,255,255,0.02)" }}>
-              <td><strong>Total</strong></td>
-              {activeCols.map(c => (<td key={c.key}><strong>{(totals as any)[c.key] ?? "—"}</strong></td>))}
+            <tr className="table-row table-row--total">
+              <td className="text-left">Total</td>
+              {activeCols.map(c => (
+                <td key={c.key} className={c.key === "name" ? "text-left" : "text-right"}>
+                  {(totals as any)[c.key] ?? "—"}
+                </td>
+              ))}
             </tr>
           </tbody>
         </table>

--- a/src/components/SplitControlsRow.tsx
+++ b/src/components/SplitControlsRow.tsx
@@ -7,12 +7,6 @@ type Props = {
   onIncludeAllChange: (value: boolean) => void;
 };
 
-const chip = {
-  surface: { background: "#111315", border: "1px solid #27292B" },
-  inner:   { background: "#0E1011" },
-  textMut: { color: "#BDBDBD" },
-};
-
 export default function SplitControlsRow({
   mode,
   includeAll,
@@ -22,95 +16,47 @@ export default function SplitControlsRow({
   const toggleDisabled = mode !== "auto";
 
   return (
-    <div style={{ ...chip.surface, borderRadius: 16, padding: 12 }} data-testid="split-controls-row">
-      <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
-        {/* Mode pill */}
-        <span
-          style={{
-            ...chip.inner,
-            border: "1px solid #27292B",
-            borderRadius: 999,
-            padding: "6px 12px",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 8,
-            fontSize: 14,
-          }}
-        >
-          <span style={{ width: 8, height: 8, borderRadius: 999, background: "#7C3AED" }} />
-          <span>Mode: {mode === "auto" ? "Auto" : "Manual"}</span>
+    <div className="planner-mode" data-testid="split-controls-row">
+      <div className="planner-mode__top">
+        <span className="planner-mode__chip">
+          <span className="planner-mode__chip-dot" />
+          Mode: {mode === "auto" ? "Auto" : "Manual"}
         </span>
-
-        {/* removed Include-all status pill */}
-
-        {/* removed Platforms count pill */}
-
-        {/* Segmented control */}
-        <div
-          style={{
-            marginLeft: "auto",
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-            flexWrap: "wrap",
-            justifyContent: "flex-end",
-          }}
-        >
-          <div style={{ ...chip.inner, border: "1px solid #27292B", borderRadius: 12, padding: 4, display: "flex" }}>
-            <button
-              onClick={() => onChangeMode("auto")}
-              style={{
-                padding: "6px 14px",
-                fontSize: 14,
-                borderRadius: 8,
-                background: mode === "auto" ? "#2C2C2C" : "transparent",
-                color: mode === "auto" ? "#FFFFFF" : "#BDBDBD",
-                transition: "background .15s ease, color .15s ease",
-                border: "none",
-                cursor: "pointer",
-              }}
-            >
-              Auto
-            </button>
-            <button
-              onClick={() => onChangeMode("manual")}
-              style={{
-                padding: "6px 14px",
-                fontSize: 14,
-                borderRadius: 8,
-                background: mode === "manual" ? "#2C2C2C" : "transparent",
-                color: mode === "manual" ? "#FFFFFF" : "#BDBDBD",
-                transition: "background .15s ease, color .15s ease",
-                border: "none",
-                cursor: "pointer",
-              }}
-            >
-              Manual
-            </button>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <label
-              className="switch"
-              title="Give every selected platform at least 10% of the budget in auto mode"
-              aria-label="Give every selected platform at least 10% of the budget in auto mode"
-              style={{
-                opacity: toggleDisabled ? 0.4 : 1,
-                pointerEvents: toggleDisabled ? "none" : "auto",
-                cursor: toggleDisabled ? "not-allowed" : "pointer",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={includeAll}
-                onChange={(e) => onIncludeAllChange(e.target.checked)}
-                disabled={toggleDisabled}
-              />
-              <span className="slider" />
-            </label>
-            <span style={{ fontSize: 13, color: "#BDBDBD" }}>
-              Min 10% each{toggleDisabled ? ' (auto only)' : ''}
+      </div>
+      <div className="planner-mode__row">
+        <div className="planner-seg" role="group" aria-label="Allocation mode">
+          <button
+            type="button"
+            className={mode === "auto" ? "is-active" : ""}
+            onClick={() => onChangeMode("auto")}
+          >
+            Auto
+          </button>
+          <button
+            type="button"
+            className={mode === "manual" ? "is-active" : ""}
+            onClick={() => onChangeMode("manual")}
+          >
+            Manual
+          </button>
+        </div>
+        <div className="planner-toggle">
+          <label
+            className={`planner-switch${toggleDisabled ? " is-disabled" : ""}`}
+            title="Give every selected platform at least 10% of the budget in auto mode"
+            aria-label="Give every selected platform at least 10% of the budget in auto mode"
+          >
+            <input
+              type="checkbox"
+              checked={includeAll}
+              onChange={(e) => onIncludeAllChange(e.target.checked)}
+              disabled={toggleDisabled}
+            />
+            <span className="planner-switch__track">
+              <span className="planner-switch__thumb" />
             </span>
-          </div>
+          </label>
+          <span>Min 10% each{toggleDisabled ? ' (auto only)' : ''}</span>
         </div>
       </div>
     </div>

--- a/src/components/ui/AnimatedCounter.tsx
+++ b/src/components/ui/AnimatedCounter.tsx
@@ -1,0 +1,36 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import { useMemo } from 'react';
+
+type AnimatedCounterProps = {
+  value: number | null | undefined;
+  formatter?: (value: number) => string;
+  fallback?: string;
+  className?: string;
+};
+
+export function AnimatedCounter({ value, formatter, fallback = '—', className }: AnimatedCounterProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const display = useMemo(() => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return fallback;
+    }
+    return formatter ? formatter(value) : new Intl.NumberFormat('en-US').format(value);
+  }, [value, formatter, fallback]);
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return <span className={className}>{display}</span>;
+  }
+
+  return (
+    <motion.span
+      key={`${display}-${value}`}
+      className={className}
+      initial={prefersReducedMotion ? { opacity: 0.7 } : { scale: 0.96, opacity: 0.7 }}
+      animate={prefersReducedMotion ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+      transition={{ duration: 0.32, ease: [0.16, 1, 0.3, 1] }}
+    >
+      {display}
+    </motion.span>
+  );
+}

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -116,113 +116,23 @@
 }
 
 :root{
-  --bg-elev-1:#151821;
-  --bg-elev-2:#171a23;
-  --card:#17191f;
-  --card-2:#14161d;
-  --text:#fff;
-  --muted:#A8B1C0;
-  --line:#252832;
-  --focus:#7C4DFF;            /* Deep purple accent used across app */
-  --chip:#6D28D9;
-  --chip-weak:#3B2B5F;
-  --success:#1DB954;
-  --danger:#EF4444;
-  --radius:16px;
-  --space-1:8px; --space-2:12px; --space-3:16px; --space-4:20px; --space-5:28px;
-  --field-h:44px; --field-px:12px;
-  --shadow:0 10px 24px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.02);
+  --bg-elev-1:rgba(255,255,255,0.02);
+  --bg-elev-2:rgba(255,255,255,0.05);
+  --card:linear-gradient(180deg, rgba(22,30,45,0.88), rgba(12,18,30,0.94));
+  --card-2:rgba(9,14,22,0.92);
+  --text:var(--fg);
+  --muted:rgba(255,255,255,0.60);
+  --line:rgba(255,255,255,0.08);
+  --focus:#3E8BFF;
+  --chip:var(--ac-1);
+  --chip-weak:rgba(62,139,255,0.08);
+  --success:#32D583;
+  --danger:#F97066;
+  --radius:24px;
+  --space-1:8px; --space-2:12px; --space-3:16px; --space-4:24px; --space-5:32px;
+  --field-h:48px; --field-px:16px;
+  --shadow:0 8px 32px rgba(0,0,0,0.45);
 }
-
-.mp-card{
-  background:var(--card);
-  border:1px solid var(--line);
-  border-radius:var(--radius);
-  padding:var(--space-5);
-  box-shadow:var(--shadow);
-  color:var(--text);
-}
-.mp-card__header{
-  display:flex; align-items:center; justify-content:space-between;
-  margin-bottom:var(--space-4);
-}
-.mp-title{font-weight:700; letter-spacing:.2px; font-size:20px;}
-.mp-badges{display:flex; gap:8px; flex-wrap:wrap}
-
-.mp-grid{
-  display:grid;
-  gap:var(--space-4);
-  grid-template-columns:repeat(12,1fr);
-}
-.mp-col-6{grid-column:span 6}
-@media (max-width: 960px){ .mp-col-6{grid-column:span 12} }
-
-.mp-field{display:flex; flex-direction:column; gap:6px;}
-.mp-label{
-  font-size:12px; letter-spacing:.4px; text-transform:uppercase;
-  color:#cdd5e0;
-}
-.mp-hint{font-size:12px; color:var(--muted)}
-.mp-input, .mp-select{
-  height:var(--field-h);
-  border-radius:12px;
-  border:1px solid var(--line);
-  background:var(--card-2);
-  color:var(--text);
-  padding:0 var(--field-px);
-  outline:none;
-}
-.mp-input:focus, .mp-select:focus{
-  border-color:var(--focus);
-  box-shadow:0 0 0 3px rgba(124,77,255,.25);
-}
-
-/* Platform chips */
-.mp-chips{display:flex; gap:8px; flex-wrap:wrap}
-.mp-chip{
-  background:var(--chip-weak);
-  color:#E9D5FF;
-  border:1px solid #4b3a7a;
-  height:32px; padding:0 12px; border-radius:20px;
-  font-weight:600; font-size:12px;
-  display:inline-flex; align-items:center; gap:8px;
-  transition:transform .15s ease, background .2s ease, border .2s ease;
-}
-.mp-chip:hover{transform:translateY(-1px)}
-.mp-chip.is-active{
-  background:var(--focus);
-  border-color:var(--focus);
-  color:#fff;
-}
-
-/* Segmented control (Auto / Manual) */
-.mp-seg{
-  display:inline-flex; background:#0f1117; border:1px solid var(--line); border-radius:12px;
-  padding:4px; gap:4px;
-}
-.mp-seg button{
-  min-width:88px; height:34px; border-radius:8px; border:none; cursor:pointer;
-  color:#cfd6e2; background:transparent; font-weight:600;
-}
-.mp-seg button.is-active{background:var(--focus); color:#fff}
-
-/* Modern switch */
-.mp-switch{display:flex; align-items:center; gap:12px}
-.mp-switch input[type="checkbox"]{display:none}
-.mp-switch .track{
-  width:44px; height:24px; border-radius:999px; background:#2a2f3a; position:relative; border:1px solid var(--line);
-}
-.mp-switch .thumb{
-  width:18px; height:18px; border-radius:50%; background:#cfd6e2;
-  position:absolute; top:2px; left:2px; transition:all .18s ease;
-  box-shadow:0 2px 6px rgba(0,0,0,.35)
-}
-.mp-switch input:checked + .track{background:var(--focus); border-color:var(--focus)}
-.mp-switch input:checked + .track .thumb{left:calc(100% - 20px); background:#fff}
-
-/* Inline meta row */
-.mp-meta{display:flex; gap:10px; flex-wrap:wrap; margin-top:4px}
-.mp-dot{width:6px; height:6px; border-radius:50%; background:#667085; display:inline-block; margin-right:6px}
 
 /* Optional: selected bar label chip */
 .chart-chip {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,20 +1,52 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 :root{
-  --bg:#121212; --fg:#FFFFFF; --muted:#BDBDBD; --primary:#673AB7; --accent:#FF4081;
-  --inputBg:#1d1d1f; --border:#2b2b2e;
-  --surface1:#1a1a1c; --surface2:#202023;
-  --radius:20px; --radius-sm:12px; --ring:rgba(103,58,183,.35);
-  --shadow:0 12px 36px rgba(0,0,0,.40), 0 1px 0 rgba(255,255,255,.02) inset;
+  --bg:#060a11;
+  --fg:rgba(231,236,243,0.90);
+  --muted:rgba(255,255,255,0.60);
+  --fg-strong:#FFFFFF;
+  --primary:#3E8BFF;
+  --accent:#6B70FF;
+  --inputBg:rgba(255,255,255,0.04);
+  --border:rgba(255,255,255,0.06);
+  --surface1:rgba(255,255,255,0.03);
+  --surface2:rgba(255,255,255,0.06);
+  --radius:24px;
+  --radius-sm:16px;
+  --ring:rgba(62,139,255,0.35);
+  --shadow:0 8px 32px rgba(0,0,0,0.45);
+  --inner-highlight:0 1px 0 rgba(255,255,255,0.04) inset;
+  --ac-1:#3E8BFF;
+  --ac-2:#6B70FF;
+  --field-h:48px;
+  --field-px:20px;
 }
 html,body,#root{height:100%}
-body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--fg);
+  font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+}
 
 /* App bar (sticky, blurred) */
 .appbar{position:sticky;top:0;z-index:20;background:linear-gradient(180deg, rgba(18,18,18,.9), rgba(18,18,18,.6));backdrop-filter:blur(8px)}
 
 /* Cards & sections */
-.card{background:linear-gradient(180deg,var(--surface2),var(--surface1));border:1px solid var(--border);
-      border-radius:var(--radius);box-shadow:var(--shadow)}
+.card{
+  position:relative;
+  background:linear-gradient(180deg, rgba(24,31,46,0.86), rgba(12,18,28,0.92));
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+}
+.card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  box-shadow:var(--inner-highlight);
+  pointer-events:none;
+}
 .h1{font-size:28px;font-weight:800;letter-spacing:-.2px}
 .h2{font-size:12px;font-weight:700;color:var(--muted);letter-spacing:.4px}
 
@@ -66,15 +98,6 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 .chip:hover{transform:translateY(-1px);background:#2a2a2f}
 .chip[aria-pressed="true"]{background:var(--primary);color:#fff;border-color:#6c39d8}
 
-/* KPI group (FIX for broken corners / harsh lines) */
-.kpiGroup{border-radius:var(--radius);background:var(--border);padding:1px;box-shadow:var(--shadow)}
-.kpiGrid{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border);
-  border-radius:calc(var(--radius) - 1px);overflow:hidden}
-@media (min-width:768px){.kpiGrid{grid-template-columns:repeat(4,1fr)}}
-.kpiCell{background:var(--surface1);padding:16px 18px}
-.kpiLabel{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px}
-.kpiValue{margin-top:4px;font-size:24px;font-weight:700;letter-spacing:-.2px;font-variant-numeric:tabular-nums}
-
 /* Table (pill rows) */
 .tableWrap{overflow:auto;border-radius:var(--radius)}
 .table{width:100%;border-collapse:separate;border-spacing:0 8px}
@@ -99,15 +122,477 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 /* ==== PREMIUM APP BACKGROUND & TYPOGRAPHY ==== */
 .appBg{
   position:relative;
+  min-height:100vh;
   background:
-    radial-gradient(1200px 800px at 10% -20%, rgba(103,58,183,.18), transparent 55%),
-    radial-gradient(900px 600px at 90% 120%, rgba(255,64,129,.12), transparent 55%),
-    linear-gradient(180deg, #0F1012 0%, #0F1012 100%);
+    radial-gradient(1200px 900px at -10% -20%, rgba(62,139,255,0.20), transparent 65%),
+    radial-gradient(1000px 800px at 120% 130%, rgba(107,112,255,0.18), transparent 65%),
+    linear-gradient(to bottom, rgba(16,22,30,0.55), rgba(10,14,20,0.55));
 }
-.appBg::after{content:"";position:fixed;inset:0;pointer-events:none;background:radial-gradient(1200px 800px at 50% -20%, rgba(255,255,255,.06), transparent 60%);mix-blend-mode:overlay;opacity:.35}
+.appBg::after{
+  content:"";
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  background:
+    radial-gradient(1000px 700px at 50% -10%, rgba(255,255,255,0.08), transparent 65%);
+  mix-blend-mode:overlay;
+  opacity:.32;
+  transition:opacity .35s ease;
+}
+body.planner-in .appBg::after{opacity:.18}
+
+/* ==== Planner Hero & Layout ==== */
+.planner-shell{
+  padding-block:clamp(36px,8vw,96px);
+}
+
+.planner-grid{
+  max-width:1200px;
+  margin:0 auto;
+  padding-inline:clamp(24px,4vw,32px);
+  display:grid;
+  gap:clamp(32px,5vw,48px);
+}
+
+.planner-card-wrap,
+.planner-copy{
+  display:flex;
+  flex-direction:column;
+  gap:clamp(16px,3vw,24px);
+}
+
+.planner-card{
+  position:relative;
+  background:linear-gradient(180deg, rgba(22,30,45,0.92), rgba(9,13,22,0.96));
+  border:1px solid var(--border);
+  border-radius:32px;
+  padding:clamp(24px,3vw,32px);
+  color:var(--fg);
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(18px);
+}
+
+.planner-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  box-shadow:var(--inner-highlight);
+  pointer-events:none;
+}
+
+.planner-card__content{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.planner-tag{
+  font-size:12px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.24em;
+  color:rgba(255,255,255,0.48);
+  margin-bottom:6px;
+}
+
+.planner-field{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.planner-label{
+  font-size:12px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.24em;
+  color:var(--muted);
+}
+
+.planner-hint{
+  font-size:12px;
+  color:rgba(231,236,243,0.55);
+}
+
+.planner-input,
+.planner-select{
+  height:var(--field-h);
+  border-radius:999px;
+  border:1px solid transparent;
+  background:var(--inputBg);
+  color:var(--fg);
+  padding:0 var(--field-px);
+  font-size:15px;
+  font-weight:500;
+  letter-spacing:.01em;
+  transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.planner-input::placeholder{color:rgba(231,236,243,0.45)}
+
+.planner-input:focus,
+.planner-select:focus{
+  outline:none;
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(62,139,255,0.55);
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-select{
+  appearance:none;
+  background-image:linear-gradient(45deg, transparent 50%, rgba(231,236,243,0.7) 50%),
+    linear-gradient(135deg, rgba(231,236,243,0.7) 50%, transparent 50%);
+  background-position:calc(100% - 22px) calc(50% - 3px), calc(100% - 16px) calc(50% - 3px);
+  background-size:6px 6px, 6px 6px;
+  background-repeat:no-repeat;
+  padding-right:48px;
+}
+
+.planner-select option{
+  background:#0b1019;
+  color:var(--fg-strong);
+}
+
+.planner-objectives,
+.planner-chips{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.planner-pill,
+.planner-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.05);
+  background:rgba(255,255,255,0.04);
+  color:rgba(231,236,243,0.88);
+  font-size:14px;
+  font-weight:600;
+  letter-spacing:.01em;
+  transition:transform .18s ease, box-shadow .18s ease, background .18s ease, color .18s ease;
+  cursor:pointer;
+}
+
+.planner-pill:hover,
+.planner-chip:hover{
+  box-shadow:inset 0 0 0 1px rgba(114,137,218,0.25);
+}
+
+.planner-pill.is-active,
+.planner-chip.is-active{
+  color:#fff;
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  border-color:transparent;
+  box-shadow:inset 0 0 18px rgba(114,137,218,0.4), 0 10px 28px rgba(8,12,20,0.45);
+}
+
+.planner-pill:focus-visible,
+.planner-chip:focus-visible,
+.planner-btn:focus-visible,
+.planner-input:focus-visible,
+.planner-select:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-mode{
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:24px;
+  padding:18px;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.planner-mode__top{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  align-items:center;
+}
+
+.planner-mode__chip{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  color:rgba(231,236,243,0.88);
+  font-size:13px;
+  font-weight:600;
+}
+
+.planner-mode__chip-dot{
+  width:8px;
+  height:8px;
+  border-radius:999px;
+  background:var(--ac-1);
+  box-shadow:0 0 12px rgba(62,139,255,0.45);
+}
+
+.planner-mode__row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:center;
+  justify-content:space-between;
+}
+
+.planner-seg{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:4px;
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,0.05);
+  background:rgba(255,255,255,0.04);
+}
+
+.planner-seg button{
+  min-width:96px;
+  height:36px;
+  border-radius:12px;
+  border:none;
+  background:transparent;
+  color:rgba(231,236,243,0.7);
+  font-weight:600;
+  letter-spacing:.01em;
+  cursor:pointer;
+  transition:background .2s ease, color .2s ease, box-shadow .2s ease;
+}
+
+.planner-seg button.is-active{
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  color:#fff;
+  box-shadow:inset 0 0 14px rgba(114,137,218,0.42);
+}
+
+.planner-seg button:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-toggle{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  color:rgba(231,236,243,0.72);
+  font-size:13px;
+}
+
+.planner-switch{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  width:52px;
+  height:28px;
+  cursor:pointer;
+}
+
+.planner-switch input{opacity:0;width:0;height:0}
+
+.planner-switch__track{
+  position:absolute;
+  inset:0;
+  border-radius:999px;
+  background:rgba(255,255,255,0.05);
+  border:1px solid rgba(255,255,255,0.08);
+  transition:background .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.planner-switch__thumb{
+  position:absolute;
+  top:50%;
+  left:6px;
+  width:20px;
+  height:20px;
+  border-radius:999px;
+  background:#ECF3FF;
+  transform:translate(0,-50%);
+  box-shadow:0 6px 18px rgba(8,12,20,0.45);
+  transition:transform .22s cubic-bezier(.4,0,.2,1), background .2s ease;
+}
+
+.planner-switch input:checked + .planner-switch__track{
+  background:linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  border-color:rgba(62,139,255,0.65);
+  box-shadow:0 0 12px rgba(62,139,255,0.35);
+}
+
+.planner-switch input:checked + .planner-switch__track .planner-switch__thumb{
+  transform:translate(22px,-50%);
+  background:#fff;
+}
+
+.planner-switch:focus-within .planner-switch__track{
+  box-shadow:0 0 0 2px var(--ring);
+}
+
+.planner-switch.is-disabled{
+  opacity:0.4;
+  cursor:not-allowed;
+}
+
+.planner-eyebrow{
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  color:rgba(255,255,255,0.45);
+}
+
+.planner-heading{
+  margin:0;
+  font-weight:800;
+  font-size:clamp(28px,4vw,72px);
+  line-height:1.05;
+  color:var(--fg-strong);
+}
+
+.planner-subcopy{
+  font-size:clamp(16px,1.2vw,20px);
+  color:rgba(231,236,243,0.82);
+  max-width:42ch;
+}
+
+.planner-note{
+  font-size:14px;
+  color:rgba(255,255,255,0.4);
+  max-width:48ch;
+}
+
+.planner-cta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:center;
+}
+
+.planner-btn{
+  border:none;
+  outline:none;
+  cursor:pointer;
+  font:inherit;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  font-weight:600;
+  letter-spacing:.02em;
+  transition:transform .2s ease, box-shadow .2s ease, filter .2s ease;
+}
+
+.planner-btn-primary{
+  flex:1 1 240px;
+  height:48px;
+  border-radius:999px;
+  background:linear-gradient(180deg,#0D1C2A,#152A43);
+  color:#ECF3FF;
+  box-shadow:inset 0 1px 0 rgba(236,243,255,0.16), 0 16px 42px rgba(5,12,24,0.45);
+  border:1px solid rgba(62,139,255,0.25);
+}
+
+.planner-btn-primary:hover{
+  filter:brightness(1.05);
+}
+
+.planner-btn-primary:active{
+  transform:scale(.98);
+  box-shadow:inset 0 1px 0 rgba(236,243,255,0.12), 0 8px 24px rgba(5,12,24,0.45);
+}
+
+.planner-link{
+  color:rgba(255,255,255,0.5);
+  text-decoration:none;
+  font-weight:600;
+  transition:color .2s ease;
+}
+
+.planner-link:hover{color:rgba(255,255,255,0.8)}
+
+.planner-link:focus-visible{
+  outline:none;
+  box-shadow:0 1px 0 rgba(255,255,255,0.55);
+}
+
+@media (max-width:1023px){
+  .planner-card-wrap{order:1}
+  .planner-copy{order:2}
+  .planner-cta{flex-direction:column;align-items:stretch;gap:8px}
+  .planner-btn-primary{flex:1 1 auto;width:100%}
+}
+
+@media (min-width:1024px){
+  .planner-grid{grid-template-columns:repeat(12,minmax(0,1fr));align-items:start}
+  .planner-card-wrap{grid-column:span 7;order:2}
+  .planner-copy{grid-column:span 5;order:1}
+}
+
+/* ==== KPI Summary ==== */
+.kpi-panel{
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:28px;
+  padding:24px;
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(14px);
+}
+
+.kpi-panel .planner-tag{margin-bottom:14px;color:rgba(255,255,255,0.5)}
+
+.kpi-list{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+
+.kpi-row{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:16px 20px;
+  border-radius:20px;
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.04);
+  backdrop-filter:blur(6px);
+}
+
+.kpi-label{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  font-size:13px;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.18em;
+  color:rgba(231,236,243,0.68);
+}
+
+.kpi-dot{
+  width:10px;
+  height:10px;
+  border-radius:999px;
+  box-shadow:0 0 0 4px rgba(255,255,255,0.04);
+}
+
+.kpi-dot--accent{background:linear-gradient(135deg,var(--ac-1),var(--ac-2))}
+.kpi-dot--reach{background:#4ade80}
+.kpi-dot--efficiency{background:#60a5fa}
+.kpi-dot--confidence{background:#c084fc}
+
+.kpi-value{
+  font-size:28px;
+  font-weight:700;
+  color:var(--fg-strong);
+  font-variant-numeric:tabular-nums;
+}
 
 /* ==== GLOBAL RHYTHM ==== */
-.container{max-width:1160px;margin-inline:auto;padding-inline:16px}
+.container{max-width:1200px;margin-inline:auto;padding-inline:clamp(24px,5vw,32px)}
 .section{margin-block:32px}
 .stack-4 > * + *{margin-top:12px}
 .stack-6 > * + *{margin-top:24px}
@@ -159,12 +644,13 @@ body{margin:0;background:var(--bg);color:var(--fg);font-family:Inter,system-ui,-
 .comfy .table tbody td{padding:14px 12px}
 
 /* --- Cell visuals --- */
-.badgeTiny{font-size:11px;color:#BDBDBD;padding:2px 6px;border:1px solid var(--border);border-radius:999px}
+.badgeTiny{font-size:11px;color:rgba(231,236,243,0.72);padding:2px 6px;border:1px solid var(--border);border-radius:999px}
 .progressCell{display:flex;align-items:center;gap:8px}
-.progressBar{flex:1;height:6px;background:#25262b;border-radius:999px;overflow:hidden}
-.progressInner{height:100%;background:linear-gradient(90deg,#5B8CFF,#7F55E0);border-radius:999px}
-.warn{background:rgba(255,180,90,.08)}
-.good{background:rgba(139,209,124,.08)}
+.progressBar{flex:1;height:8px;background:rgba(255,255,255,0.1);border-radius:999px;overflow:hidden;position:relative}
+.progressInner{height:100%;background:linear-gradient(90deg,rgba(62,139,255,0.6),rgba(107,112,255,0.6));border-radius:inherit;transition:width .42s cubic-bezier(.23,1,.32,1),filter .2s ease}
+.progressBar:hover .progressInner{filter:brightness(1.06)}
+.warn{background:rgba(249,112,102,0.08)}
+.good{background:rgba(50,213,131,0.08)}
 
 /* ---- Header chips (replace white badges) ---- */
 .thChip{

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,27 +1,74 @@
 :root {
-  --card-bg: #111315;
-  --card-inner: #0E1011;
-  --card-border: #27292B;
-  --divider: #1C1E20;
-  --text: #FFFFFF;
-  --muted: #BDBDBD;
-  --chip: #2C2C2C;
-  --accent: #7C3AED;
-  --radius-lg: 16px;
-  --radius-md: 12px;
+  --card-bg: linear-gradient(180deg, rgba(22, 30, 45, 0.88), rgba(9, 13, 22, 0.94));
+  --card-inner: rgba(255, 255, 255, 0.03);
+  --card-border: rgba(255, 255, 255, 0.06);
+  --card-divider: rgba(255, 255, 255, 0.05);
+  --text: rgba(231, 236, 243, 0.9);
+  --text-strong: #ffffff;
+  --muted: rgba(231, 236, 243, 0.62);
+  --chip: rgba(255, 255, 255, 0.06);
+  --chip-border: rgba(255, 255, 255, 0.08);
+  --radius-lg: 28px;
+  --radius-md: 20px;
 }
 
 .app-card {
+  position: relative;
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: var(--radius-lg);
   background: var(--card-bg);
   border: 1px solid var(--card-border);
-  border-radius: var(--radius-lg);
   color: var(--text);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.app-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  pointer-events: none;
 }
 
 .app-card--inner {
   background: var(--card-inner);
   border: 1px solid var(--card-border);
   border-radius: var(--radius-md);
+  padding: clamp(16px, 2.5vw, 20px);
+  backdrop-filter: blur(12px);
+}
+
+.app-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--card-divider);
+}
+
+.app-card__eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.app-card__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.app-card__subtitle {
+  font-size: 14px;
+  color: rgba(231, 236, 243, 0.6);
 }
 
 .app-chip {
@@ -29,132 +76,256 @@
   align-items: center;
   gap: 8px;
   background: var(--chip);
-  color: var(--text);
-  padding: 6px 12px;
+  border: 1px solid var(--chip-border);
   border-radius: 999px;
+  color: var(--text-strong);
+  padding: 6px 12px;
   font-size: 13px;
-  border: 1px solid var(--card-border);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 0 0 1px rgba(62, 139, 255, 0.08);
 }
 
 .app-dot {
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: var(--accent);
-}
-
-.table-wrap {
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-}
-
-.table-head {
-  background: var(--card-inner);
-  border-bottom: 1px solid var(--card-border);
-}
-
-.table-head th {
-  color: var(--muted);
-  font-weight: 600;
-  font-size: 12px;
-  letter-spacing: 0.02em;
-  padding: 10px 12px;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.table-row {
-  border-top: 1px solid var(--divider);
-}
-
-.table-row:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.table-row td {
-  padding: 12px;
-  font-size: 14px;
-  color: var(--text);
-}
-
-.table-badge {
-  background: #1A1C1E;
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  padding: 2px 8px;
-  font-size: 12px;
-  color: var(--muted);
+  background: linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  box-shadow: 0 0 12px rgba(62, 139, 255, 0.35);
 }
 
 .table-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 12px 8px;
-  background: var(--card-bg);
+  gap: 12px;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--card-border);
+  border-radius: calc(var(--radius-md) + 4px);
 }
 
 .search-input {
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
+  flex: 1 1 260px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   color: var(--text);
-  border-radius: 10px;
-  padding: 8px 12px;
+  border-radius: 999px;
+  padding: 10px 16px;
   font-size: 14px;
-  width: 320px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .search-input::placeholder {
-  color: var(--muted);
+  color: rgba(231, 236, 243, 0.48);
 }
 
 .search-input:focus {
   outline: none;
-  border-color: var(--accent);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(62, 139, 255, 0.55);
+  box-shadow: 0 0 0 2px var(--ring);
 }
 
 .columns-btn {
   margin-left: auto;
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
-  color: var(--muted);
-  border-radius: 10px;
-  padding: 8px 12px;
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(231, 236, 243, 0.78);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
 }
 
 .columns-btn:hover {
-  background: var(--chip);
+  background: rgba(62, 139, 255, 0.12);
+  border-color: rgba(62, 139, 255, 0.45);
+  color: var(--text-strong);
+}
+
+.columns-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
+}
+
+.columns-btn:active {
+  transform: scale(0.98);
+}
+
+.table-wrap {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--card-border);
+  border-radius: calc(var(--radius-lg) - 4px);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.app-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table-head {
+  background: rgba(8, 14, 22, 0.78);
+}
+
+.table-head th {
+  color: rgba(231, 236, 243, 0.62);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 14px 16px;
+  text-align: left;
+}
+
+.table-row {
+  background: rgba(13, 19, 29, 0.64);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background 0.2s ease;
+}
+
+.table-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.table-row td {
+  padding: 14px 16px;
+  font-size: 14px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.table-row--total {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.table-row--total td {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.table-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: rgba(231, 236, 243, 0.78);
 }
 
 .kpi-row {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-  padding: 12px;
-  border-bottom: 1px solid var(--card-border);
-  background: var(--card-bg);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
 }
 
 .kpi-tile {
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-md);
-  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 18px;
+  padding: 14px 16px;
+  backdrop-filter: blur(10px);
 }
 
 .kpi-label {
-  color: var(--muted);
+  color: rgba(231, 236, 243, 0.62);
   font-size: 12px;
-  margin-bottom: 2px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
 }
 
 .kpi-value {
-  color: var(--text);
+  color: var(--text-strong);
   font-size: 18px;
   font-weight: 700;
+}
+
+.recommendations-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.recommendations-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  color: rgba(231, 236, 243, 0.74);
+  line-height: 1.6;
+}
+
+.recommendations-item .app-dot {
+  margin-top: 6px;
+}
+
+.columns-dialog {
+  width: min(440px, 92vw);
+}
+
+.columns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.columns-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.columns-option:hover {
+  background: rgba(62, 139, 255, 0.12);
+  border-color: rgba(62, 139, 255, 0.4);
+}
+
+.columns-option input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ac-1);
+}
+
+.columns-option span {
+  color: var(--text);
+}
+
+.columns-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.columns-footer .columns-btn {
+  margin-left: 0;
+}
+
+@media (max-width: 640px) {
+  .table-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .columns-btn {
+    width: 100%;
+  }
 }

--- a/src/ui/AppCard.tsx
+++ b/src/ui/AppCard.tsx
@@ -1,8 +1,8 @@
-import type { PropsWithChildren } from "react";
+import type { HTMLAttributes, PropsWithChildren } from "react";
 
-export default function AppCard({ children, className = "" }: PropsWithChildren<{className?: string}>) {
+export default function AppCard({ children, className = "", ...props }: PropsWithChildren<HTMLAttributes<HTMLElement>>) {
   return (
-    <section className={`app-card ${className}`} style={{ padding: 12 }}>
+    <section className={`app-card ${className}`.trim()} {...props}>
       {children}
     </section>
   );


### PR DESCRIPTION
## Summary
- restyle the shared app card, table, and toolbar surfaces with the deep navy gradient, translucent borders, and glow effects from the updated palette
- rebuild the channel breakdown and recommendations cards to use the shared scaffolding, translucent KPI tiles, and gradient chips
- update the CTA stack animation and column picker dialog to live inside the themed motion/card shell with descriptive copy

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations)*
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc53e4d3e483219fac52f34e16db6f