### PR TITLE
Polish hero layout and unify card styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,17 +287,6 @@ function App() {
       : { opacity: 1, y: 0, transition: baseTransition },
   }), [prefersReducedMotion, baseTransition]);
 
-  const scrollToSection = useCallback((id: string) => {
-    if (typeof document === 'undefined') return;
-    const node = document.getElementById(id);
-    if (node) {
-      node.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, []);
-
-  const scrollToResults = useCallback(() => scrollToSection('results-section'), [scrollToSection]);
-  const scrollToAdvanced = useCallback(() => scrollToSection('advanced-planner'), [scrollToSection]);
-
   // Prepare data for charts and table
   const rowsFmt = results.map(r => ({
     platform: r.platform,
@@ -449,32 +438,6 @@ function App() {
             <motion.div className="planner-copy" variants={itemVariants}>
               <span className="planner-tag">Live preview</span>
               <h2 className="planner-heading">Plan a sample campaign</h2>
-              <p className="planner-subcopy">
-                Tune budgets, objectives, and assumptions to watch cross-channel performance update instantly.
-              </p>
-              <p className="planner-note">
-                Numbers refresh in real time as you edit inputs. Scroll for full results or jump into advanced controls.
-              </p>
-              <div className="planner-cta">
-                <motion.button
-                  type="button"
-                  className="planner-btn planner-btn-primary"
-                  onClick={scrollToResults}
-                  whileHover={prefersReducedMotion ? undefined : { y: -1 }}
-                  whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
-                >
-                  See full results →
-                </motion.button>
-                <motion.button
-                  type="button"
-                  className="planner-btn planner-link"
-                  onClick={scrollToAdvanced}
-                  whileHover={prefersReducedMotion ? undefined : { y: -1 }}
-                  whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
-                >
-                  Open advanced planner →
-                </motion.button>
-              </div>
             </motion.div>
             <motion.div className="planner-card-wrap" variants={itemVariants}>
               <MediaPlannerCard
@@ -514,9 +477,7 @@ function App() {
         <section id="results-section" className="section">
           <div className="container flex flex-col gap-8">
             {results.length > 0 && (
-              <div className="max-w-3xl">
-                <KpiCards totals={totals} currency={currency} />
-              </div>
+              <KpiCards totals={totals} currency={currency} />
             )}
             <div className="grid gap-6 lg:grid-cols-2">
               <BudgetDonutPro

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -63,7 +63,14 @@ body{
 .groupTitle{font-size:12px;font-weight:700;color:var(--muted);letter-spacing:.4px;margin:6px 0}
 
 /* subcards for nested inputs (e.g., manual splits / CPLs) */
-.subCard{background:var(--surface1);border:1px solid var(--border);border-radius:14px;padding:12px}
+.subCard{
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:20px;
+  padding:18px;
+  backdrop-filter:blur(12px);
+  box-shadow:var(--shadow);
+}
 
 /* input with suffix affix */
 .inputAffix{position:relative}
@@ -72,11 +79,14 @@ body{
 /* ---- SWITCH (accessible, Slack-style) ---- */
 .toggleRow{
   display:flex;align-items:center;justify-content:space-between;
-  gap:12px;background:var(--surface1);border:1px solid var(--border);
-  border-radius:14px;padding:12px 14px
+  gap:16px;background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:22px;padding:18px 20px;
+  backdrop-filter:blur(12px);
+  box-shadow:var(--shadow);
 }
 .toggleText{display:flex;flex-direction:column;gap:2px}
-.toggleTitle{font-weight:600}
+.toggleTitle{font-weight:700;color:var(--fg-strong)}
 .toggleHelp{font-size:12px;color:var(--muted)}
 .switch{
   position:relative;width:44px;height:26px;border-radius:999px;border:1px solid var(--border);
@@ -538,6 +548,10 @@ body.planner-in .appBg::after{opacity:.18}
   padding:24px;
   box-shadow:var(--shadow);
   backdrop-filter:blur(14px);
+  width:100%;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
 }
 
 .kpi-panel .planner-tag{margin-bottom:14px;color:rgba(255,255,255,0.5)}
@@ -901,35 +915,89 @@ body.planner-in .appBg::after{opacity:.18}
 .chip:hover { filter:brightness(1.05); }
 
 /* ---- Card container (same as results) ---- */
-.cardPro { background:linear-gradient(180deg,var(--surface2),var(--surface1));
-  border:1px solid var(--border); border-radius:16px; box-shadow:var(--elev); }
+.cardPro {
+  background:rgba(255,255,255,0.03);
+  border:1px solid rgba(255,255,255,0.05);
+  border-radius:28px;
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(14px);
+}
 
 /* Header row in cards */
-.cardHead { display:flex; align-items:center; justify-content:space-between; gap:12px;
-  padding:12px 14px; border-bottom:1px solid var(--border); }
-.cardEyebrow { font-size:11px; letter-spacing:.4px; color:#BDBDBD; text-transform:uppercase; font-weight:700; }
+.cardHead {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  padding:22px 24px 16px;
+  border-bottom:1px solid rgba(255,255,255,0.05);
+  background:rgba(12,18,28,0.32);
+}
+.cardEyebrow {
+  font-size:11px;
+  letter-spacing:.4px;
+  color:rgba(231,236,243,0.62);
+  text-transform:uppercase;
+  font-weight:700;
+}
 .cardActions { display:flex; gap:8px; }
-.cardBtn { height:32px; padding:0 12px; border:1px solid var(--border); border-radius:10px; background:#1a1b1f; color:#fff; }
-.cardBody { padding:12px 14px; }
+.cardBtn {
+  height:36px;
+  padding:0 18px;
+  border:1px solid rgba(255,255,255,0.1);
+  border-radius:999px;
+  background:rgba(255,255,255,0.06);
+  color:#ecf3ff;
+  font-weight:600;
+  backdrop-filter:blur(10px);
+  transition:transform .18s ease, background .18s ease;
+}
+.cardBtn:hover { background:rgba(107,112,255,0.24); transform:translateY(-1px); }
+.cardBody { padding:20px 24px 24px; }
 
 /* Two-column responsive grid */
-.grid2 { display:grid; gap:12px; grid-template-columns:repeat(2,minmax(0,1fr)); }
+.grid2 { display:grid; gap:16px; grid-template-columns:repeat(2,minmax(0,1fr)); }
 @media (max-width:980px){ .grid2{ grid-template-columns:1fr; } }
 
 /* Field row with pill input */
-.fieldRow{ display:grid; align-items:center; gap:8px; grid-template-columns:1fr auto;
-  background:#141519; border:1px solid var(--border); border-radius:12px; padding:10px 12px; }
-.fieldLabel{ font-weight:700; color:#D9DADE; }
-.pillInput{ display:flex; align-items:center; gap:6px;
-  background:#1a1b1f; border:1px solid var(--border); border-radius:999px; padding:4px 10px; }
-.pillInput input{ width:110px; background:transparent; border:none; outline:none; color:#fff; text-align:right; }
-.pillSuf{ color:#BDBDBD; font-weight:600; }
+.fieldRow{
+  display:grid;
+  align-items:center;
+  gap:12px;
+  grid-template-columns:1fr auto;
+  background:rgba(255,255,255,0.04);
+  border:1px solid rgba(255,255,255,0.08);
+  border-radius:22px;
+  padding:16px 20px;
+  backdrop-filter:blur(12px);
+}
+.fieldLabel{ font-weight:700; color:#ECF3FF; letter-spacing:.01em; }
+.pillInput{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  background:rgba(6,10,17,0.65);
+  border:1px solid rgba(255,255,255,0.1);
+  border-radius:999px;
+  padding:6px 14px;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.08);
+}
+.pillInput input{ width:110px; background:transparent; border:none; outline:none; color:#fff; text-align:right; font-weight:600; }
+.pillSuf{ color:rgba(231,236,243,0.7); font-weight:600; letter-spacing:.02em; }
 
 /* Sum bar for % split */
-.sumWrap{ margin-top:12px; display:flex; align-items:center; gap:10px; }
-.sumText{ font-size:12px; color:#BDBDBD; }
+.sumWrap{ margin-top:16px; display:flex; align-items:center; gap:12px; }
+.sumText{ font-size:12px; color:rgba(231,236,243,0.72); }
 .sumText.ok{ color:#8BD17C; } .sumText.warn{ color:#F5B971; }
-.sumBar{ flex:1; height:8px; border-radius:999px; background:#26272c; overflow:hidden; border:1px solid var(--border); }
+.sumBar{
+  flex:1;
+  height:10px;
+  border-radius:999px;
+  background:rgba(6,10,17,0.65);
+  overflow:hidden;
+  border:1px solid rgba(255,255,255,0.1);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.08);
+}
 .sumInner{ height:100%; background:linear-gradient(90deg,#5B8CFF,#7F55E0); width:0%; transition:width .2s ease; }
 
 /* ===== Active Settings strip ===== */
@@ -999,10 +1067,11 @@ body.planner-in .appBg::after{opacity:.18}
 
 /* ===== Section card (consistent with results) ===== */
 .sectionCard {
-  background: linear-gradient(180deg, var(--surface2), var(--surface1));
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  box-shadow: var(--elev);
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
   overflow: hidden;
 }
 .sectionHead {
@@ -1010,31 +1079,78 @@ body.planner-in .appBg::after{opacity:.18}
   grid-template-columns: 1fr auto;
   gap: 12px;
   align-items: center;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
+  padding: 22px 24px 16px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  background: rgba(12,18,28,0.32);
 }
 .sectionTitle {
-  display: flex; flex-direction: column; gap: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 .sectionTitle .eyebrow {
-  font-size: 11px; letter-spacing: .4px; text-transform: uppercase; color: #BDBDBD; font-weight: 700;
+  font-size: 11px;
+  letter-spacing: .4px;
+  text-transform: uppercase;
+  color: rgba(231,236,243,0.62);
+  font-weight: 700;
 }
-.sectionTitle .sub { color: #9aa0a6; font-size: 12px; }
+.sectionTitle .sub {
+  color: rgba(231,236,243,0.78);
+  font-size: 14px;
+  font-weight: 600;
+}
 
-.sectionActions { display: flex; align-items: center; gap: 8px; }
-.secBtn { height: 32px; padding: 0 12px; border: 1px solid var(--border); border-radius: 10px; background: #1a1b1f; color: #fff; }
-.secBtn.primary { background: var(--primary); border-color: #6c39d8; }
+.sectionActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.secBtn {
+  height: 36px;
+  padding: 0 18px;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 999px;
+  background: rgba(255,255,255,0.06);
+  color: #ecf3ff;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+  transition: transform .18s ease, background .18s ease;
+}
+.secBtn:hover {
+  background: rgba(107,112,255,0.24);
+  transform: translateY(-1px);
+}
+.secBtn.primary {
+  background: linear-gradient(135deg, var(--ac-1), var(--ac-2));
+  border-color: rgba(107,112,255,0.6);
+  color: #fff;
+}
 
-.sectionBody { padding: 14px 16px; display: grid; gap: 12px; }
+.sectionBody {
+  padding: 20px 24px 24px;
+  display: grid;
+  gap: 16px;
+}
 .rowCard {
-  display: flex; align-items: center; justify-content: space-between; gap: 10px;
-  background: #141519; border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 22px;
+  padding: 18px 22px;
+  backdrop-filter: blur(12px);
 }
-.rowCard .title { color: #D9DADE; font-weight: 700; }
-.rowCard .sub { color: #BDBDBD; font-size: 12px; margin-top: 2px; }
-.rowCard.warn { border-color: #5e471c; background: #231c0e; }
-.rowCard.warn .title { color: #ffe2b0; }
-.rowCard.warn .sub { color: #d4a574; }
+.rowCard .title { color: #ECF3FF; font-weight: 700; letter-spacing: .01em; }
+.rowCard .sub { color: rgba(231,236,243,0.7); font-size: 12px; margin-top: 4px; }
+.rowCard.warn {
+  border-color: rgba(255, 184, 79, 0.55);
+  background: rgba(68, 48, 12, 0.45);
+}
+.rowCard.warn .title { color: #ffe8bc; }
+.rowCard.warn .sub { color: #f5d08a; }
 
 /* Tiny mode segment */
 .modeSeg { display:inline-flex; background:#1a1b1f; border:1px solid var(--border); border-radius:10px; padding:2px; }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,14 +1,14 @@
 :root {
-  --card-bg: #111315;
-  --card-inner: #0E1011;
-  --card-border: #27292B;
-  --divider: #1C1E20;
-  --text: #FFFFFF;
-  --muted: #BDBDBD;
-  --chip: #2C2C2C;
-  --accent: #7C3AED;
-  --radius-lg: 16px;
-  --radius-md: 12px;
+  --card-bg: rgba(255, 255, 255, 0.03);
+  --card-inner: rgba(255, 255, 255, 0.05);
+  --card-border: rgba(255, 255, 255, 0.06);
+  --divider: rgba(255, 255, 255, 0.05);
+  --text: #ecf3ff;
+  --muted: rgba(231, 236, 243, 0.62);
+  --chip: rgba(255, 255, 255, 0.08);
+  --accent: #6b70ff;
+  --radius-lg: 28px;
+  --radius-md: 20px;
 }
 
 .app-card {
@@ -16,12 +16,16 @@
   border: 1px solid var(--card-border);
   border-radius: var(--radius-lg);
   color: var(--text);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+  padding: 24px;
 }
 
 .app-card--inner {
   background: var(--card-inner);
-  border: 1px solid var(--card-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-md);
+  backdrop-filter: blur(10px);
 }
 
 .app-chip {
@@ -33,7 +37,8 @@
   padding: 6px 12px;
   border-radius: 999px;
   font-size: 13px;
-  border: 1px solid var(--card-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 20px rgba(6, 10, 17, 0.25);
 }
 
 .app-dot {
@@ -44,15 +49,16 @@
 }
 
 .table-wrap {
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: calc(var(--radius-lg) - 10px);
   overflow: hidden;
+  backdrop-filter: blur(12px);
 }
 
 .table-head {
-  background: var(--card-inner);
-  border-bottom: 1px solid var(--card-border);
+  background: rgba(12, 20, 30, 0.35);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .table-head th {
@@ -66,11 +72,12 @@
 }
 
 .table-row {
-  border-top: 1px solid var(--divider);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background 0.2s ease;
 }
 
 .table-row:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .table-row td {
@@ -80,30 +87,32 @@
 }
 
 .table-badge {
-  background: #1A1C1E;
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--text);
+  font-weight: 600;
 }
 
 .table-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 12px 8px;
-  background: var(--card-bg);
+  gap: 12px;
+  padding-bottom: 16px;
 }
 
 .search-input {
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   color: var(--text);
-  border-radius: 10px;
-  padding: 8px 12px;
+  border-radius: 999px;
+  padding: 10px 16px;
   font-size: 14px;
-  width: 320px;
+  width: min(320px, 100%);
+  backdrop-filter: blur(10px);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
 .search-input::placeholder {
@@ -113,48 +122,53 @@
 .search-input:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(107, 112, 255, 0.2);
 }
 
 .columns-btn {
   margin-left: auto;
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
-  color: var(--muted);
-  border-radius: 10px;
-  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 8px 16px;
   font-size: 14px;
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: transform 0.18s ease, background 0.18s ease;
+  backdrop-filter: blur(10px);
 }
 
 .columns-btn:hover {
-  background: var(--chip);
+  background: rgba(107, 112, 255, 0.22);
+  transform: translateY(-1px);
 }
 
 .kpi-row {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-  padding: 12px;
-  border-bottom: 1px solid var(--card-border);
-  background: var(--card-bg);
+  gap: 12px;
 }
 
 .kpi-tile {
-  background: var(--card-inner);
-  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-md);
-  padding: 10px 12px;
+  padding: 14px 16px;
+  backdrop-filter: blur(10px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .kpi-label {
   color: var(--muted);
   font-size: 12px;
-  margin-bottom: 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 6px;
 }
 
 .kpi-value {
   color: var(--text);
-  font-size: 18px;
+  font-size: 22px;
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }

--- a/src/ui/AppCard.tsx
+++ b/src/ui/AppCard.tsx
@@ -1,8 +1,9 @@
 import type { PropsWithChildren } from "react";
 
 export default function AppCard({ children, className = "" }: PropsWithChildren<{className?: string}>) {
+  const cardClass = ["app-card", className].filter(Boolean).join(" ");
   return (
-    <section className={`app-card ${className}`} style={{ padding: 12 }}>
+    <section className={cardClass}>
       {children}
     </section>
   );


### PR DESCRIPTION
## Summary
- remove the hero subcopy and CTA so the hero matches the new brief while keeping the KPI card in view
- let the KPI summary card span the container and reuse its frosted-glass treatment for other app/section cards
- refresh shared card, table, and control styles (including manual split and CPL areas) to use the updated glass variables

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68ccda8550108321b5cecd5d05aae093