### PR TITLE
Refine KPI layout and integrate CPL toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import './styles/theme.css'
 import './styles/charts.css'
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type Dispatch, type SetStateAction } from 'react';
 import { motion, useInView, useReducedMotion, cubicBezier } from 'framer-motion';
 import type { Platform, Goal, Market, Currency } from './lib/assumptions';
 import { NICHE_DEFAULTS } from './lib/assumptions';
@@ -436,8 +436,12 @@ function App() {
         >
           <motion.div className="planner-grid" variants={gridVariants}>
             <motion.div className="planner-copy" variants={itemVariants}>
-              <span className="planner-tag">Live preview</span>
-              <h2 className="planner-heading">Plan a sample campaign</h2>
+              <KpiCards
+                totals={totals}
+                currency={currency}
+                manualCpl={manualCPL}
+                onManualCplChange={setManualCPL}
+              />
             </motion.div>
             <motion.div className="planner-card-wrap" variants={itemVariants}>
               <MediaPlannerCard
@@ -476,9 +480,6 @@ function App() {
 
         <section id="results-section" className="section">
           <div className="container flex flex-col gap-8">
-            {results.length > 0 && (
-              <KpiCards totals={totals} currency={currency} />
-            )}
             <div className="grid gap-6 lg:grid-cols-2">
               <BudgetDonutPro
                 data={donutData}
@@ -562,15 +563,43 @@ function App() {
 
 
 // KPI Cards Component
-function KpiCards({ totals, currency }: { totals: any; currency: string }) {
+function KpiCards({
+  totals,
+  currency,
+  manualCpl,
+  onManualCplChange,
+}: {
+  totals: any;
+  currency: string;
+  manualCpl: boolean;
+  onManualCplChange: Dispatch<SetStateAction<boolean>> | ((value: boolean) => void);
+}) {
   const budget = typeof totals?.budget === 'number' ? totals.budget : null;
   const reach = typeof totals?.reach === 'number' ? totals.reach : null;
   const cpl = typeof totals?.cpl === 'number' ? totals.cpl : null;
   const roas = typeof totals?.roas === 'number' ? totals.roas : null;
+  const statusTitle = manualCpl ? 'Manual CPL per platform' : 'Auto CPL is ON';
+  const statusSub = manualCpl
+    ? 'Override lead cost per platform in the advanced controls below.'
+    : 'Using model defaults. Toggle to override per-platform CPL.';
 
   return (
     <section className="kpi-panel">
       <div className="planner-tag">KPI summary</div>
+      <div className="kpi-status">
+        <div className="kpi-status__text">
+          <div className="kpi-status__title">{statusTitle}</div>
+          <div className="kpi-status__sub">{statusSub}</div>
+        </div>
+        <label className="switch" title="Enable manual CPL per platform" aria-label="Enable manual CPL per platform">
+          <input
+            type="checkbox"
+            checked={manualCpl}
+            onChange={(event) => onManualCplChange(event.target.checked)}
+          />
+          <span className="slider" />
+        </label>
+      </div>
       <div className="kpi-list">
         <div className="kpi-row">
           <div className="kpi-label">

--- a/src/components/CostOverridesCard.tsx
+++ b/src/components/CostOverridesCard.tsx
@@ -48,8 +48,8 @@ export function CostOverridesCard({
       ) : (
         <div className="rowCard">
           <div>
-            <div className="title">Auto CPL is ON</div>
-            <div className="sub">Turn on manual CPL to override per-platform cost of lead.</div>
+            <div className="title">Auto CPL is active</div>
+            <div className="sub">Use the KPI summary toggle above to enable manual overrides when you need them.</div>
           </div>
         </div>
       )}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -556,10 +556,32 @@ body.planner-in .appBg::after{opacity:.18}
 
 .kpi-panel .planner-tag{margin-bottom:14px;color:rgba(255,255,255,0.5)}
 
+.kpi-status{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  padding:18px 20px;
+  border-radius:22px;
+  background:rgba(255,255,255,0.035);
+  border:1px solid rgba(255,255,255,0.05);
+  backdrop-filter:blur(10px);
+}
+
+.kpi-status__text{display:flex;flex-direction:column;gap:6px;color:rgba(231,236,243,0.82)}
+.kpi-status__title{font-size:15px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#f1f5ff}
+.kpi-status__sub{font-size:12px;color:rgba(231,236,243,0.68);letter-spacing:.02em;line-height:1.4}
+.kpi-status .switch{flex-shrink:0}
+
 .kpi-list{
   display:flex;
   flex-direction:column;
   gap:14px;
+}
+
+@media (max-width:640px){
+  .kpi-status{flex-direction:column;align-items:flex-start;gap:12px}
+  .kpi-status .switch{align-self:flex-end}
 }
 
 .kpi-row{


### PR DESCRIPTION
## Summary
- replace the hero copy with the KPI summary card and surface the CPL toggle beside the metrics
- update the cost override helper text to point users to the KPI summary toggle
- extend KPI styling to support the new status block and mobile layout adjustments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cce71c03148321929befbf15d92b47