### PR TITLE
Refine planner cards with unified styling and inline splits editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import type { ExportPayload } from './export';
 import type { AppState } from './lib/storage';
 import { saveState, loadState } from './lib/storage';
 import { Download, Settings } from 'lucide-react';
-import { PLATFORM_LABELS, formatNumber, formatCurrency } from './lib/utils';
+import { PLATFORM_LABELS, formatNumber, formatCurrency, cn } from './lib/utils';
 import { BudgetDonutPro, ImpressionsBarsPro } from './components/ChartsPro';
 import ResultsByPlatformCard from './components/ResultsByPlatformCard';
 import ColumnsDialog from './components/ColumnsDialog';
@@ -26,6 +26,7 @@ import { hasRate } from './lib/fx';
 import MediaPlannerCard from './components/MediaPlannerCard';
 import ChannelsSplitsCard from './components/ChannelsSplitsCard';
 import { AnimatedCounter } from './components/ui/AnimatedCounter';
+import { Card, microTitleClass } from './components/ui/Card';
 
 const ALL_PLATFORMS: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'GOOGLE_SEARCH', 'GOOGLE_DISPLAY', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];
 const PLATFORM_NAME_MAP: Record<string, string> = Object.fromEntries(
@@ -476,6 +477,10 @@ function App() {
                     return [...prev, platform];
                   });
                 }}
+                currency={currency}
+                manualCpl={manualCPL}
+                platformCPLs={platformCPLs}
+                setPlatformCPLs={setPlatformCPLs}
               />
             </motion.div>
           </motion.div>
@@ -581,75 +586,97 @@ function KpiCards({
   const reach = typeof totals?.reach === 'number' ? totals.reach : null;
   const cpl = typeof totals?.cpl === 'number' ? totals.cpl : null;
   const roas = typeof totals?.roas === 'number' ? totals.roas : null;
-  const statusTitle = manualCpl ? 'Manual CPL per platform' : 'Auto CPL is ON';
-  const statusSub = manualCpl
-    ? 'Override lead cost per platform in the advanced controls below.'
-    : 'Using model defaults. Toggle to override per-platform CPL.';
+  const autoEnabled = !manualCpl;
+
+  const metrics = [
+    {
+      key: 'budget',
+      label: 'Budget',
+      value: budget,
+      formatter: (value: number) => formatCurrency(value, currency),
+      dotClass: 'bg-brand/80',
+    },
+    {
+      key: 'reach',
+      label: 'Reach',
+      value: reach,
+      formatter: (value: number) => formatNumber(value),
+      dotClass: 'bg-emerald-400/80',
+    },
+    {
+      key: 'cpl',
+      label: 'Efficiency (CPL)',
+      value: cpl,
+      formatter: (value: number) => formatCurrency(value, currency),
+      dotClass: 'bg-cyan-300/80',
+    },
+    {
+      key: 'roas',
+      label: 'Confidence (ROAS)',
+      value: roas,
+      formatter: (value: number) => `${value.toFixed(2)}x`,
+      dotClass: 'bg-violet-300/80',
+    },
+  ];
+
+  const helperCopy = manualCpl
+    ? 'Manual CPL per platform enabled. Adjust overrides below.'
+    : 'Uses model defaults. Toggle to override per-platform CPL.';
 
   return (
-    <section className="kpi-panel">
-      <div className="planner-tag">KPI summary</div>
-      <div className="kpi-status">
-        <div className="kpi-status__text">
-          <div className="kpi-status__title">{statusTitle}</div>
-          <div className="kpi-status__sub">{statusSub}</div>
-        </div>
-        <label className="switch" title="Enable manual CPL per platform" aria-label="Enable manual CPL per platform">
-          <input
-            type="checkbox"
-            checked={manualCpl}
-            onChange={(event) => onManualCplChange(event.target.checked)}
-          />
-          <span className="slider" />
-        </label>
-      </div>
-      <div className="kpi-list">
-        <div className="kpi-row">
-          <div className="kpi-label">
-            <span className="kpi-dot kpi-dot--accent" />
-            <span>Budget</span>
+    <Card>
+      <header className="space-y-1">
+        <span className={microTitleClass}>KPI Summary</span>
+      </header>
+      <div className="space-y-2 rounded-xl bg-surface-3/70 p-3 ring-1 ring-white/10 md:p-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-semibold text-white/80">Auto CPL</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={autoEnabled}
+              onClick={() => onManualCplChange(!manualCpl)}
+              className={cn(
+                'relative h-8 w-14 rounded-full transition-colors duration-200 ring-1 ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+                autoEnabled ? 'bg-brand/40 ring-brand/30' : 'bg-surface-2'
+              )}
+            >
+              <span className="sr-only">Toggle manual CPL per platform</span>
+              <span
+                className={cn(
+                  'absolute left-1 top-1 h-6 w-6 rounded-full bg-white/90 transition-transform duration-200',
+                  autoEnabled ? 'translate-x-6' : 'translate-x-0'
+                )}
+              />
+            </button>
+            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/50">
+              {autoEnabled ? 'On' : 'Off'}
+            </span>
           </div>
-          <AnimatedCounter
-            value={budget}
-            formatter={(value) => formatCurrency(value, currency)}
-            className="kpi-value"
-          />
-        </div>
-        <div className="kpi-row">
-          <div className="kpi-label">
-            <span className="kpi-dot kpi-dot--reach" />
-            <span>Reach</span>
-          </div>
-          <AnimatedCounter
-            value={reach}
-            formatter={(value) => formatNumber(value)}
-            className="kpi-value"
-          />
-        </div>
-        <div className="kpi-row">
-          <div className="kpi-label">
-            <span className="kpi-dot kpi-dot--efficiency" />
-            <span>Efficiency (CPL)</span>
-          </div>
-          <AnimatedCounter
-            value={cpl}
-            formatter={(value) => formatCurrency(value, currency)}
-            className="kpi-value"
-          />
-        </div>
-        <div className="kpi-row">
-          <div className="kpi-label">
-            <span className="kpi-dot kpi-dot--confidence" />
-            <span>Confidence (ROAS)</span>
-          </div>
-          <AnimatedCounter
-            value={roas}
-            formatter={(value) => `${value.toFixed(2)}x`}
-            className="kpi-value"
-          />
+          <p className="text-[12px] text-white/60 sm:text-right">{helperCopy}</p>
         </div>
       </div>
-    </section>
+
+      <div className="space-y-2">
+        {metrics.map((metric) => (
+          <div
+            key={metric.key}
+            className="flex h-9 items-center justify-between rounded-full bg-surface-3/70 px-3 text-xs font-medium text-white/70 ring-1 ring-white/10"
+          >
+            <div className="flex items-center gap-2">
+              <span className={cn('h-2 w-2 rounded-full', metric.dotClass)} aria-hidden="true" />
+              <span>{metric.label}</span>
+            </div>
+            <AnimatedCounter
+              value={metric.value}
+              formatter={metric.formatter as (value: number) => string}
+              className="text-sm font-semibold text-white/90"
+            />
+          </div>
+        ))}
+      </div>
+    </Card>
   );
 }
 

--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -1,5 +1,21 @@
 import { useId } from 'react';
+import { Info } from 'lucide-react';
 import type { Goal, Market, Currency } from '../lib/assumptions';
+import { Card, microTitleClass } from './ui/Card';
+import { Tooltip } from './ui/Tooltip';
+
+const helperPillClass =
+  'inline-flex h-8 items-center rounded-full bg-surface-3/70 px-3 text-xs font-medium text-white/70 ring-1 ring-white/10';
+const fieldLabelClass = 'text-xs font-semibold uppercase tracking-[0.12em] text-white/60';
+const inputClass =
+  'h-10 w-full rounded-xl bg-surface-3/70 px-3 text-sm text-white/80 ring-1 ring-white/10 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40';
+const hintClass = 'text-xs text-white/50';
+
+const OBJECTIVES: { value: Goal; label: string }[] = [
+  { value: 'LEADS', label: 'Leads' },
+  { value: 'TRAFFIC', label: 'Traffic' },
+  { value: 'AWARENESS', label: 'Awareness' },
+];
 
 type Props = {
   totalBudget: number;
@@ -19,7 +35,23 @@ type Props = {
   nicheOptions: string[];
 };
 
-export default function MediaPlannerCard(p: Props){
+export default function MediaPlannerCard({
+  totalBudget,
+  currency,
+  market,
+  goal,
+  niche,
+  leadToSale,
+  revenuePerSale,
+  onTotalBudgetChange,
+  onCurrencyChange,
+  onMarketChange,
+  onGoalChange,
+  onNicheChange,
+  onLeadToSaleChange,
+  onRevenuePerSaleChange,
+  nicheOptions,
+}: Props) {
   const id = useId();
   const budgetId = `${id}-budget`;
   const currencyId = `${id}-currency`;
@@ -29,58 +61,59 @@ export default function MediaPlannerCard(p: Props){
   const revenueId = `${id}-revenue`;
   const goalLabelId = `${id}-goal`;
 
-  const objectives: { value: Goal; label: string }[] = [
-    { value: 'LEADS', label: 'Leads' },
-    { value: 'TRAFFIC', label: 'Traffic' },
-    { value: 'AWARENESS', label: 'Awareness' },
-  ];
-
-  const renderObjective = (objective: { value: Goal; label: string }) => {
-    const active = p.goal === objective.value;
-    return (
-      <button
-        key={objective.value}
-        type="button"
-        className={`planner-pill${active ? ' is-active' : ''}`}
-        aria-pressed={active}
-        onClick={() => p.onGoalChange(objective.value)}
-      >
-        {objective.label}
-      </button>
-    );
-  };
-
   return (
-    <section className="planner-card" aria-labelledby={`${id}-card-title`}>
-      <div className="planner-tag" id={`${id}-card-title`}>
-        Media planner
+    <Card aria-labelledby={`${id}-card-title`}>
+      <header className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <span className={microTitleClass} id={`${id}-card-title`}>
+            Media Planner
+          </span>
+          <p className="text-[13px] text-white/70">Budget, market, goal, currency.</p>
+        </div>
+        <Tooltip content="Set budget, currency, market, and goal. Powers planner & AI prompts.">
+          <button
+            type="button"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full text-white/60 ring-1 ring-white/10 transition hover:text-white/80 hover:ring-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+            aria-label="Media planner help"
+          >
+            <Info className="h-4 w-4" />
+          </button>
+        </Tooltip>
+      </header>
+
+      <div className="flex flex-wrap gap-2 md:gap-3">
+        {['Budget', 'Currency', 'Market', 'Goal'].map((pill) => (
+          <span key={pill} className={helperPillClass}>
+            {pill}
+          </span>
+        ))}
       </div>
-      <div className="planner-card__content">
-        <div>
-          <div className="planner-tag">Campaign inputs</div>
-          <label className="planner-field" htmlFor={budgetId}>
-            <span className="planner-label">Total budget</span>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-4">
+          <label className="flex flex-col gap-2" htmlFor={budgetId}>
+            <span className={fieldLabelClass}>Total budget</span>
             <input
               id={budgetId}
-              className="planner-input"
+              className={inputClass}
               type="number"
               inputMode="numeric"
               min={0}
               step={100}
-              value={p.totalBudget}
-              onChange={(e) => p.onTotalBudgetChange(Number(e.target.value) || 0)}
+              value={Number.isFinite(totalBudget) ? totalBudget : 0}
+              onChange={(event) => onTotalBudgetChange(Number(event.target.value) || 0)}
               placeholder="Enter media spend only"
             />
-            <span className="planner-hint">Media spend only; excludes management/design fees.</span>
+            <span className={hintClass}>Media spend only; excludes management/design fees.</span>
           </label>
 
-          <label className="planner-field" htmlFor={currencyId}>
-            <span className="planner-label">Currency</span>
+          <label className="flex flex-col gap-2" htmlFor={currencyId}>
+            <span className={fieldLabelClass}>Currency</span>
             <select
               id={currencyId}
-              className="planner-select"
-              value={p.currency}
-              onChange={(e) => p.onCurrencyChange(e.target.value as Currency)}
+              className={inputClass}
+              value={currency}
+              onChange={(event) => onCurrencyChange(event.target.value as Currency)}
             >
               <option value="EGP">EGP</option>
               <option value="USD">USD</option>
@@ -91,15 +124,14 @@ export default function MediaPlannerCard(p: Props){
           </label>
         </div>
 
-        <div>
-          <div className="planner-tag">Targeting</div>
-          <label className="planner-field" htmlFor={marketId}>
-            <span className="planner-label">Market</span>
+        <div className="space-y-4">
+          <label className="flex flex-col gap-2" htmlFor={marketId}>
+            <span className={fieldLabelClass}>Market</span>
             <select
               id={marketId}
-              className="planner-select"
-              value={p.market}
-              onChange={(e) => p.onMarketChange(e.target.value as Market)}
+              className={inputClass}
+              value={market}
+              onChange={(event) => onMarketChange(event.target.value as Market)}
             >
               <option value="Egypt">Egypt</option>
               <option value="Saudi Arabia">Saudi Arabia</option>
@@ -108,60 +140,78 @@ export default function MediaPlannerCard(p: Props){
             </select>
           </label>
 
-          <label className="planner-field" htmlFor={nicheId}>
-            <span className="planner-label">Niche</span>
+          <label className="flex flex-col gap-2" htmlFor={nicheId}>
+            <span className={fieldLabelClass}>Niche</span>
             <select
               id={nicheId}
-              className="planner-select"
-              value={p.niche}
-              onChange={(e) => p.onNicheChange(e.target.value)}
+              className={inputClass}
+              value={niche}
+              onChange={(event) => onNicheChange(event.target.value)}
             >
-              {p.nicheOptions.map((option) => (
-                <option key={option} value={option}>{option}</option>
+              {nicheOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
               ))}
             </select>
-            <span className="planner-hint">Auto-sets close rate & revenue per sale (editable).</span>
-          </label>
-
-          <label className="planner-field" htmlFor={leadSaleId}>
-            <span className="planner-label">Lead→Sale %</span>
-            <input
-              id={leadSaleId}
-              className="planner-input"
-              type="number"
-              inputMode="decimal"
-              min={0}
-              max={100}
-              step={1}
-              value={p.leadToSale}
-              onChange={(e) => p.onLeadToSaleChange(Number(e.target.value) || 0)}
-            />
-          </label>
-
-          <label className="planner-field" htmlFor={revenueId}>
-            <span className="planner-label">Revenue per sale</span>
-            <input
-              id={revenueId}
-              className="planner-input"
-              type="number"
-              inputMode="decimal"
-              min={0}
-              step={50}
-              value={p.revenuePerSale}
-              onChange={(e) => p.onRevenuePerSaleChange(Number(e.target.value) || 0)}
-            />
+            <span className={hintClass}>Auto-sets close rate & revenue per sale (editable).</span>
           </label>
         </div>
-
-        <div>
-          <div className="planner-tag" id={goalLabelId}>Objective</div>
-          <div className="planner-objectives" role="group" aria-labelledby={goalLabelId}>
-            {objectives.map(renderObjective)}
-          </div>
-          <span className="planner-hint">Adjusts auto budget split unless manual % is on.</span>
-        </div>
-
       </div>
-    </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col gap-2" htmlFor={leadSaleId}>
+          <span className={fieldLabelClass}>Lead→Sale %</span>
+          <input
+            id={leadSaleId}
+            className={inputClass}
+            type="number"
+            inputMode="decimal"
+            min={0}
+            max={100}
+            step={1}
+            value={Number.isFinite(leadToSale) ? leadToSale : 0}
+            onChange={(event) => onLeadToSaleChange(Number(event.target.value) || 0)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-2" htmlFor={revenueId}>
+          <span className={fieldLabelClass}>Revenue per sale</span>
+          <input
+            id={revenueId}
+            className={inputClass}
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step={50}
+            value={Number.isFinite(revenuePerSale) ? revenuePerSale : 0}
+            onChange={(event) => onRevenuePerSaleChange(Number(event.target.value) || 0)}
+          />
+        </label>
+      </div>
+
+      <div className="space-y-3" role="group" aria-labelledby={goalLabelId}>
+        <span className={fieldLabelClass} id={goalLabelId}>
+          Objective
+        </span>
+        <div className="flex flex-wrap gap-2 md:gap-3">
+          {OBJECTIVES.map((objective) => {
+            const active = goal === objective.value;
+            return (
+              <button
+                key={objective.value}
+                type="button"
+                className={`${helperPillClass} ${active ? 'bg-brand/10 text-brand-100 ring-brand/30' : ''}`}
+                aria-pressed={active}
+                onClick={() => onGoalChange(objective.value)}
+              >
+                {objective.label}
+              </button>
+            );
+          })}
+        </div>
+        <span className={hintClass}>Adjusts auto budget split unless manual % is on.</span>
+      </div>
+    </Card>
   );
 }

--- a/src/components/RecommendationsCard.tsx
+++ b/src/components/RecommendationsCard.tsx
@@ -1,21 +1,19 @@
-import AppCard from "../ui/AppCard";
+import { Card, microTitleClass } from "./ui/Card";
 
 export default function RecommendationsCard({ items }: { items: string[] }) {
   return (
-    <AppCard className="mt-4">
-      <div style={{ padding:"12px 12px 4px", borderBottom:"1px solid var(--card-border)" }}>
-        <div style={{ fontWeight:700, letterSpacing:.2, color: "var(--text)" }}>RECOMMENDATIONS</div>
-      </div>
-      <div className="app-card--inner" style={{ margin:12, padding:12 }}>
-        <ul style={{ display:"grid", gap:8 }}>
-          {items.map((t, i) => (
-            <li key={i} style={{ display:"flex", alignItems:"flex-start", gap:8, color:"var(--muted)", lineHeight:1.5 }}>
-              <span className="app-dot" style={{ marginTop:6 }} />
-              <span>{t}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </AppCard>
+    <Card>
+      <header className="space-y-1">
+        <span className={microTitleClass}>Recommendations</span>
+      </header>
+      <ul className="space-y-1.5 text-[13px] text-white/70">
+        {items.map((recommendation, index) => (
+          <li key={index} className="flex items-start gap-2">
+            <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-brand" aria-hidden="true" />
+            <span>{recommendation}</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
   );
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from 'react';
+import type { HTMLAttributes } from 'react';
+
+import { cn } from '../../lib/utils';
+
+export type CardProps = HTMLAttributes<HTMLElement>;
+
+export const Card = forwardRef<HTMLElement, CardProps>(function Card(
+  { className, ...props },
+  ref
+) {
+  return (
+    <section
+      ref={ref}
+      className={cn(
+        'isolate space-y-3 rounded-2xl bg-surface-2 p-4 md:p-5 ring-1 ring-white/10 shadow-soft',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+export const microTitleClass =
+  'text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60';

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -33,7 +33,7 @@ export function Tooltip({ content, side = "top", maxWidth = 280, children }: Pro
         flip = true;
       }
       // Clamp horizontally inside viewport
-      let left = Math.min(Math.max(8, r.left), window.innerWidth - maxWidth - 8);
+      const left = Math.min(Math.max(8, r.left), window.innerWidth - maxWidth - 8);
 
       setPos({ top, left, flip });
     };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,15 @@ export default {
         inputBg: '#2C2C2C',
         border: '#333333',
         divider: '#2b2b2b',
+        surface: {
+          1: 'rgba(10, 16, 29, 0.78)',
+          2: 'rgba(12, 18, 28, 0.92)',
+          3: 'rgba(22, 30, 45, 0.78)',
+        },
+        brand: {
+          DEFAULT: '#6B70FF',
+          100: '#E0E4FF',
+        },
         'platform-facebook': '#1877F2',
         'platform-instagram': '#E1306C',
         'platform-google-search': '#4285F4',
@@ -32,6 +41,7 @@ export default {
       boxShadow: {
         'elev': '0 12px 36px rgba(0, 0, 0, .40)',
         'focus': '0 0 0 3px rgba(103, 58, 183, 0.25)',
+        'soft': '0 24px 60px rgba(3, 7, 18, 0.45)',
       },
       fontSize: {
         'xs': ['12px', '16px'],


### PR DESCRIPTION
## Summary
- introduce shared card styling tokens and a reusable Card wrapper
- restyle KPI Summary, Media Planner, Recommendations, and Channels & Splits to share the same typography, spacing, and pill controls
- embed the manual splits drawer inline with the channel card, including channel sliders, CPL overrides, and allocation utilities

## Testing
- npm run lint *(fails: repository has many existing `any` lint violations)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdd056789c832187250751dc3cef44