### PR TITLE
Fix production base path to load assets

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // Use root for local dev, repo name for GitHub Pages
-  base: process.env.NODE_ENV === 'production' ? '/media-planner-lite/' : '/',
+  // Serve from root in development and use relative paths in production so builds
+  // work whether they're deployed at the domain root or a sub-path.
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- adjust the Vite base path to emit relative asset URLs in production so builds load correctly no matter where they are hosted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdd63c197483218d62fad47fd85ce4