### PR TITLE
Refresh planner hero layout and header styling

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -27,7 +27,75 @@ body{
 }
 
 /* App bar (sticky, blurred) */
-.appbar{position:sticky;top:0;z-index:20;background:linear-gradient(180deg, rgba(18,18,18,.9), rgba(18,18,18,.6));backdrop-filter:blur(8px)}
+.appbar{
+  position:sticky;
+  top:0;
+  z-index:50;
+  background:rgba(6,10,17,0.82);
+  border-bottom:1px solid rgba(255,255,255,0.04);
+  backdrop-filter:blur(18px);
+}
+.navWrap{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:24px;
+  padding-block:18px;
+}
+.brand{
+  display:flex;
+  align-items:center;
+  gap:14px;
+}
+.brandMark{
+  width:42px;
+  height:42px;
+  border-radius:14px;
+  display:grid;
+  place-items:center;
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:0.32em;
+  text-transform:uppercase;
+  color:#fff;
+  background:radial-gradient(circle at 30% 20%, rgba(110,168,255,0.9), rgba(62,139,255,0.2));
+  box-shadow:0 10px 30px rgba(30,60,120,0.35);
+}
+.brandCopy{display:flex;flex-direction:column;gap:2px}
+.brandName{font-size:16px;font-weight:700;color:var(--fg-strong);letter-spacing:-0.01em}
+.brandSub{font-size:12px;color:rgba(231,236,243,0.65);font-weight:500}
+.navActions{display:flex;align-items:center;gap:12px}
+.exportWrap{position:relative;display:flex;align-items:center}
+.exportMenu{
+  position:absolute;
+  right:0;
+  margin-top:14px;
+  width:280px;
+  padding:18px;
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(9,14,24,0.95);
+  box-shadow:0 24px 44px rgba(6,12,24,0.55);
+  backdrop-filter:blur(18px);
+  display:grid;
+  gap:14px;
+  z-index:40;
+}
+.exportMenu__group{display:grid;gap:12px}
+.exportMenu__label{display:flex;flex-direction:column;gap:6px;font-size:12px;font-weight:600;color:rgba(231,236,243,0.72);letter-spacing:0.04em}
+.exportMenu__input{
+  height:40px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.1);
+  background:rgba(255,255,255,0.05);
+  color:#fff;
+  padding:0 12px;
+  font-size:13px;
+}
+.exportMenu__input:focus{outline:none;border-color:rgba(110,168,255,0.55);box-shadow:0 0 0 3px rgba(62,139,255,0.25)}
+.exportMenu__checkbox{display:flex;align-items:center;gap:10px;font-size:12px;color:rgba(231,236,243,0.72)}
+.exportMenu__checkbox input{accent-color:var(--ac-1)}
+.exportMenu__actions{display:grid;gap:8px}
 
 /* Cards & sections */
 .card{
@@ -124,8 +192,36 @@ body{
 /* Utilities */
 .divider{border-top:1px solid #2b2b2e}
 .badge{font-size:11px;color:var(--muted);padding:3px 8px;border:1px solid var(--border);border-radius:999px}
-.btn{height:36px;padding:0 12px;border-radius:12px;border:1px solid var(--border);background:transparent;color:var(--fg)}
-.btn.primary{background:var(--primary);color:#fff;border-color:#6c39d8}
+.btn{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  height:38px;
+  padding:0 16px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(255,255,255,0.04);
+  color:var(--fg-strong);
+  font-weight:600;
+  font-size:13px;
+  letter-spacing:0.01em;
+  transition:background .18s ease, transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.btn:hover{background:rgba(255,255,255,0.08);transform:translateY(-1px)}
+.btn:disabled{opacity:0.55;cursor:not-allowed;transform:none}
+.btn-primary,.btn.primary{
+  background:linear-gradient(135deg,var(--ac-1),var(--ac-2));
+  border-color:rgba(110,168,255,0.5);
+  color:#fff;
+  box-shadow:0 12px 24px rgba(36,64,120,0.35);
+}
+.btn-primary:hover,.btn.primary:hover{box-shadow:0 16px 30px rgba(36,64,120,0.4)}
+.btn-ghost{
+  background:rgba(255,255,255,0.05);
+  border-color:rgba(255,255,255,0.08);
+  color:rgba(231,236,243,0.85);
+}
+.btn-ghost:hover{background:rgba(255,255,255,0.08)}
 
 /* ==== PREMIUM APP BACKGROUND & TYPOGRAPHY ==== */
 .appBg{
@@ -148,6 +244,147 @@ body{
   transition:opacity .35s ease;
 }
 body.planner-in .appBg::after{opacity:.18}
+
+/* ==== HERO ==== */
+.hero{position:relative;padding-block:clamp(48px,10vw,108px)}
+.hero::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:
+    radial-gradient(70% 60% at 12% 5%, rgba(86,140,255,0.18), transparent 70%),
+    radial-gradient(60% 50% at 88% 0%, rgba(125,110,255,0.16), transparent 75%),
+    linear-gradient(180deg, rgba(8,12,20,0.92), rgba(6,10,17,0.78));
+  pointer-events:none;
+  z-index:0;
+}
+.hero-grid{
+  position:relative;
+  z-index:1;
+  max-width:1160px;
+  margin-inline:auto;
+  padding-inline:clamp(24px,4vw,32px);
+  display:grid;
+  gap:clamp(28px,6vw,48px);
+  align-items:flex-start;
+}
+@media(min-width:1024px){.hero-grid{grid-template-columns:minmax(0,1.2fr) minmax(0,1fr)}}
+.hero-copy{display:flex;flex-direction:column;gap:20px;max-width:640px}
+.hero-badge{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  height:28px;
+  padding:0 14px;
+  border-radius:999px;
+  background:rgba(62,139,255,0.16);
+  color:rgba(220,235,255,0.9);
+  font-size:11px;
+  font-weight:600;
+  letter-spacing:0.18em;
+  text-transform:uppercase;
+}
+.hero-title{
+  font-size:clamp(32px,4vw,44px);
+  font-weight:800;
+  letter-spacing:-0.02em;
+  color:var(--fg-strong);
+  margin:0;
+}
+.hero-sub{
+  margin:0;
+  font-size:15px;
+  color:rgba(231,236,243,0.78);
+  max-width:520px;
+  line-height:1.6;
+}
+.hero-list{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:10px}
+.hero-list li{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  padding:12px 16px;
+  border-radius:14px;
+  background:rgba(14,20,30,0.78);
+  border:1px solid rgba(255,255,255,0.05);
+  font-size:13px;
+  color:rgba(231,236,243,0.88);
+  box-shadow:0 14px 32px rgba(8,12,20,0.45);
+}
+.hero-list li svg{color:rgba(140,185,255,0.9)}
+.hero-meta{display:flex;flex-wrap:wrap;gap:10px}
+.hero-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 12px;
+  border-radius:999px;
+  font-size:12px;
+  font-weight:600;
+  color:rgba(231,236,243,0.82);
+  background:rgba(255,255,255,0.08);
+  border:1px solid rgba(255,255,255,0.1);
+}
+.hero-highlight{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  padding:26px;
+  border-radius:24px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:linear-gradient(205deg, rgba(24,32,48,0.95), rgba(11,16,26,0.92));
+  box-shadow:0 22px 46px rgba(6,12,24,0.55);
+  backdrop-filter:blur(18px);
+}
+@media(min-width:768px){.hero-highlight{padding:30px}}
+.hero-highlight__badge{
+  align-self:flex-start;
+  padding:6px 14px;
+  border-radius:999px;
+  border:1px solid rgba(96,140,255,0.45);
+  background:rgba(96,140,255,0.2);
+  font-size:11px;
+  letter-spacing:0.24em;
+  text-transform:uppercase;
+  color:rgba(200,216,255,0.86);
+}
+.hero-highlight__metric{display:flex;flex-direction:column;gap:6px}
+.hero-highlight__label{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.18em;
+  color:rgba(231,236,243,0.58);
+}
+.hero-highlight__value{
+  font-size:clamp(26px,3vw,34px);
+  font-weight:800;
+  color:#fff;
+}
+.hero-highlight__row{display:flex;flex-direction:column;gap:8px}
+.hero-highlight__text{
+  margin:0;
+  font-size:14px;
+  font-weight:600;
+  color:rgba(231,236,243,0.86);
+}
+.hero-platforms{display:flex;flex-wrap:wrap;gap:8px}
+.hero-platforms__chip{
+  display:inline-flex;
+  align-items:center;
+  padding:6px 12px;
+  border-radius:999px;
+  border:1px solid rgba(62,139,255,0.35);
+  background:rgba(62,139,255,0.22);
+  color:rgba(229,237,255,0.95);
+  font-size:12px;
+  font-weight:600;
+}
+.hero-platforms__chip.muted{
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(255,255,255,0.1);
+  color:rgba(231,236,243,0.55);
+}
 
 /* ==== Planner Hero & Layout ==== */
 .planner-shell{


### PR DESCRIPTION
## Summary
- redesign the sticky header with branded navigation, upgraded buttons, and a structured export menu
- introduce a hero section with guided feature bullets and a live plan snapshot card that surfaces key metrics
- expand the theme with new hero, button, and export menu styles to deliver a polished, modern first impression

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations across legacy files)*

------
https://chatgpt.com/codex/tasks/task_b_68cddf1e6eb88321938e0f41338a4cea