### PR TITLE
Polish media planner form styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { hasRate } from './lib/fx';
 import MediaPlannerCard from './components/MediaPlannerCard';
 import ChannelsSplitsCard from './components/ChannelsSplitsCard';
 import { AnimatedCounter } from './components/ui/AnimatedCounter';
-import { Card, microTitleClass } from './components/ui/Card';
+import { Card } from './components/ui/Card';
 
 const ALL_PLATFORMS: Platform[] = ['FACEBOOK', 'INSTAGRAM', 'GOOGLE_SEARCH', 'GOOGLE_DISPLAY', 'YOUTUBE', 'TIKTOK', 'LINKEDIN'];
 const PLATFORM_NAME_MAP: Record<string, string> = Object.fromEntries(
@@ -668,28 +668,28 @@ function KpiCards({
       label: 'Budget',
       value: budget,
       formatter: (value: number) => formatCurrency(value, currency),
-      dotClass: 'bg-brand/80',
+      dotClass: 'kpi-dot--accent',
     },
     {
       key: 'reach',
       label: 'Reach',
       value: reach,
       formatter: (value: number) => formatNumber(value),
-      dotClass: 'bg-emerald-400/80',
+      dotClass: 'kpi-dot--reach',
     },
     {
       key: 'cpl',
       label: 'Efficiency (CPL)',
       value: cpl,
       formatter: (value: number) => formatCurrency(value, currency),
-      dotClass: 'bg-cyan-300/80',
+      dotClass: 'kpi-dot--efficiency',
     },
     {
       key: 'roas',
       label: 'Confidence (ROAS)',
       value: roas,
       formatter: (value: number) => `${value.toFixed(2)}x`,
-      dotClass: 'bg-violet-300/80',
+      dotClass: 'kpi-dot--confidence',
     },
   ];
 
@@ -698,54 +698,43 @@ function KpiCards({
     : 'Uses model defaults. Toggle to override per-platform CPL.';
 
   return (
-    <Card>
-      <header className="space-y-1">
-        <span className={microTitleClass}>KPI Summary</span>
+    <Card className="kpi-panel">
+      <header>
+        <span className="planner-tag">KPI Summary</span>
       </header>
-      <div className="space-y-2 rounded-xl bg-surface-3/70 p-3 ring-1 ring-white/10 md:p-4">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-semibold text-white/80">Auto CPL</span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={autoEnabled}
-              onClick={() => onManualCplChange(!manualCpl)}
-              className={cn(
-                'relative h-8 w-14 rounded-full transition-colors duration-200 ring-1 ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                autoEnabled ? 'bg-brand/40 ring-brand/30' : 'bg-surface-2'
-              )}
-            >
-              <span className="sr-only">Toggle manual CPL per platform</span>
-              <span
-                className={cn(
-                  'absolute left-1 top-1 h-6 w-6 rounded-full bg-white/90 transition-transform duration-200',
-                  autoEnabled ? 'translate-x-6' : 'translate-x-0'
-                )}
-              />
-            </button>
-            <span className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/50">
-              {autoEnabled ? 'On' : 'Off'}
-            </span>
-          </div>
-          <p className="text-[12px] text-white/60 sm:text-right">{helperCopy}</p>
+
+      <div className="kpi-status">
+        <div className="kpi-status__text">
+          <span className="kpi-status__title">Auto CPL</span>
+          <span className="kpi-status__sub">{helperCopy}</span>
+        </div>
+        <div className="kpi-status__control">
+          <label className="switch" role="switch" aria-checked={autoEnabled}>
+            <span className="sr-only">Toggle manual CPL per platform</span>
+            <input
+              type="checkbox"
+              checked={autoEnabled}
+              onChange={(event) => onManualCplChange(!event.target.checked)}
+            />
+            <span className="slider" aria-hidden="true" />
+          </label>
+          <span className="kpi-status__state" aria-live="polite">
+            {autoEnabled ? 'On' : 'Off'}
+          </span>
         </div>
       </div>
 
-      <div className="space-y-2">
+      <div className="kpi-list">
         {metrics.map((metric) => (
-          <div
-            key={metric.key}
-            className="flex h-9 items-center justify-between rounded-full bg-surface-3/70 px-3 text-xs font-medium text-white/70 ring-1 ring-white/10"
-          >
-            <div className="flex items-center gap-2">
-              <span className={cn('h-2 w-2 rounded-full', metric.dotClass)} aria-hidden="true" />
+          <div key={metric.key} className="kpi-row">
+            <div className="kpi-label">
+              <span className={cn('kpi-dot', metric.dotClass)} aria-hidden="true" />
               <span>{metric.label}</span>
             </div>
             <AnimatedCounter
               value={metric.value}
               formatter={metric.formatter as (value: number) => string}
-              className="text-sm font-semibold text-white/90"
+              className="kpi-value"
             />
           </div>
         ))}

--- a/src/components/ChannelsSplitsCard.tsx
+++ b/src/components/ChannelsSplitsCard.tsx
@@ -5,7 +5,7 @@ import type { Currency, Platform } from '../lib/assumptions';
 import { PLATFORM_LABELS, cn } from '../lib/utils';
 import { Tooltip } from './ui/Tooltip';
 import { PlatformGlyph } from './PlatformGlyph';
-import { Card, microTitleClass } from './ui/Card';
+import { Card } from './ui/Card';
 
 const PLATFORM_SUMMARY_CODES: Record<Platform, string> = {
   FACEBOOK: 'FB',
@@ -335,36 +335,26 @@ export function ChannelsSplitsCard({
     mode === 'auto' ? 'Auto allocates by model CPL.' : 'Adjust % per channel.';
   const openManual = mode === 'manual' && selectedCount > 0;
 
-  const pillButtonClass =
-    'inline-flex h-8 items-center gap-2 rounded-full px-3 text-xs font-medium text-white/70 ring-1 ring-white/10 transition-colors duration-200 hover:ring-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:opacity-40 disabled:cursor-not-allowed';
-
   return (
-    <Card aria-labelledby={`${titleId}-title`}>
-      <header className="space-y-1">
-        <span id={`${titleId}-title`} className={microTitleClass}>
+    <Card aria-labelledby={`${titleId}-title`} className="channels-card">
+      <header className="channels-card__head">
+        <span id={`${titleId}-title`} className="channels-card__title">
           Channels &amp; Splits
         </span>
-        <p className="text-[13px] text-white/70">
-          Pick channels and (optional) edit manual splits.
-        </p>
+        <p className="channels-card__sub">Pick channels and (optional) edit manual splits.</p>
       </header>
 
-      <div className="space-y-3">
-        <div className="space-y-2">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/50">
-            Channels
-          </span>
-          <div className="flex flex-wrap gap-2 md:gap-3" role="group" aria-label="Select channels">
+      <div className="channels-card__body">
+        <div className="channels-row">
+          <span className="channels-row__label">Channels</span>
+          <div className="channels-pill-grid" role="group" aria-label="Select channels">
             {platforms.map((platform) => {
               const active = selectedPlatforms.includes(platform);
               return (
                 <Tooltip key={platform} content={PLATFORM_LABELS[platform] || platform}>
                   <button
                     type="button"
-                    className={cn(
-                      'flex h-9 w-9 items-center justify-center rounded-full bg-surface-3 text-white/70 ring-1 ring-white/10 transition-colors duration-200 hover:ring-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
-                      active && 'bg-brand/10 text-brand-100 ring-brand/30'
-                    )}
+                    className={cn('channel-pill', active && 'is-active')}
                     aria-pressed={active}
                     aria-label={PLATFORM_LABELS[platform] || platform}
                     onClick={() => onPlatformToggle(platform)}
@@ -377,76 +367,49 @@ export function ChannelsSplitsCard({
           </div>
         </div>
 
-        <div className="space-y-2">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/50">
-            Mode
-          </span>
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2 md:gap-3">
-              <div className="inline-flex h-9 items-center rounded-full bg-surface-3/70 p-1 ring-1 ring-white/10">
-                <button
-                  type="button"
-                  className={cn(
-                    'inline-flex h-7 items-center rounded-full px-3 text-xs font-medium text-white/70 transition-colors duration-200',
-                    mode === 'auto' && 'bg-brand/10 text-brand-100 shadow-[0_0_0_1px_rgba(107,112,255,0.24)]'
-                  )}
-                  onClick={() => handleModeChange('auto')}
-                >
-                  Auto
-                </button>
-                <button
-                  type="button"
-                  className={cn(
-                    'inline-flex h-7 items-center rounded-full px-3 text-xs font-medium text-white/70 transition-colors duration-200',
-                    mode === 'manual' && 'bg-brand/10 text-brand-100 shadow-[0_0_0_1px_rgba(107,112,255,0.24)]',
-                    disabledManual && 'opacity-40'
-                  )}
-                  onClick={() => handleModeChange('manual')}
-                  disabled={disabledManual}
-                >
-                  Manual
-                </button>
-              </div>
-              <p className="text-[12px] text-white/60">{helperText}</p>
+        <div className="channels-row channels-row--mode">
+          <span className="channels-row__label">Mode</span>
+          <div className="channels-mode">
+            <div className="channels-seg">
+              <button
+                type="button"
+                className={cn(mode === 'auto' && 'is-active')}
+                onClick={() => handleModeChange('auto')}
+              >
+                Auto
+              </button>
+              <button
+                type="button"
+                className={cn(mode === 'manual' && 'is-active')}
+                onClick={() => handleModeChange('manual')}
+                disabled={disabledManual}
+              >
+                Manual
+              </button>
             </div>
-            {disabledManual && (
-              <p className="text-[12px] text-amber-300">Select at least one channel.</p>
-            )}
+            <p className="channels-helper">{helperText}</p>
+            {disabledManual && <p className="channels-hint">Select at least one channel.</p>}
           </div>
         </div>
 
         {openManual && (
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                ref={triggerRef}
-                type="button"
-                className={cn(
-                  pillButtonClass,
-                  'items-center',
-                  drawerOpen && 'bg-brand/10 text-brand-100 ring-brand/30'
-                )}
-                onClick={toggleDrawer}
-                aria-expanded={drawerOpen}
-                aria-controls={drawerId}
-              >
-                Splits
-                <ChevronDown
-                  className={cn(
-                    'h-4 w-4 transition-transform duration-200',
-                    drawerOpen && '-rotate-180'
-                  )}
-                />
-              </button>
-              {!drawerOpen && summaryLabel && (
-                <span
-                  className="inline-flex h-8 items-center rounded-full bg-surface-3/70 px-3 text-xs text-white/70 ring-1 ring-white/10"
-                  aria-live="polite"
-                >
-                  {summaryLabel}
-                </span>
-              )}
-            </div>
+          <div className="channels-row channels-row--splits">
+            <button
+              ref={triggerRef}
+              type="button"
+              className={cn('channels-split-trigger', drawerOpen && 'is-open')}
+              onClick={toggleDrawer}
+              aria-expanded={drawerOpen}
+              aria-controls={drawerId}
+            >
+              Splits
+              <ChevronDown className="h-4 w-4" />
+            </button>
+            {!drawerOpen && summaryLabel && (
+              <span className="channels-summary" aria-live="polite">
+                {summaryLabel}
+              </span>
+            )}
           </div>
         )}
 
@@ -456,149 +419,113 @@ export function ChannelsSplitsCard({
               ref={drawerRef}
               key="splits-drawer"
               id={drawerId}
-              className="overflow-hidden rounded-2xl border border-white/10 bg-surface-3/70 p-4"
+              className="channels-drawer"
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
               transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
             >
-              <div className="space-y-4">
-                <div className="grid gap-3">
-                  {selectedPlatforms.map((platform) => {
-                    const value = Math.max(0, platformWeights[platform] ?? 0);
-                    const cplValue = platformCPLs[platform];
-                    return (
-                      <div
-                        key={platform}
-                        className="grid gap-3 rounded-2xl bg-surface-2/60 p-3 ring-1 ring-white/5 md:grid-cols-[minmax(0,1.4fr)_minmax(0,2fr)_90px_150px]"
-                      >
-                        <div className="flex items-center gap-2 text-sm font-medium text-white/80">
-                          <PlatformGlyph platform={platform} />
-                          <span>{PLATFORM_LABELS[platform] || platform}</span>
-                        </div>
-                        <div className="flex items-center">
+              <div className="channels-drawer__grid">
+                {selectedPlatforms.map((platform) => {
+                  const value = Math.max(0, platformWeights[platform] ?? 0);
+                  const cplValue = platformCPLs[platform];
+                  return (
+                    <div key={platform} className="channels-slider-row">
+                      <div className="channels-slider__label">
+                        <PlatformGlyph platform={platform} />
+                        <span>{PLATFORM_LABELS[platform] || platform}</span>
+                      </div>
+                      <div className="channels-slider__controls">
+                        <input
+                          type="range"
+                          min={0}
+                          max={100}
+                          step={1}
+                          value={value}
+                          onChange={(event) => updateValue(platform, Number(event.target.value))}
+                          aria-label={`${PLATFORM_LABELS[platform] || platform} split`}
+                        />
+                        <div className="channels-slider__input">
                           <input
-                            type="range"
+                            type="number"
                             min={0}
                             max={100}
                             step={1}
-                            value={value}
-                            onChange={(event) =>
-                              updateValue(platform, Number(event.target.value))
-                            }
-                            aria-label={`${PLATFORM_LABELS[platform] || platform} split`}
-                            className="h-1.5 w-full accent-brand"
+                            value={Number.isFinite(value) ? value : 0}
+                            onChange={(event) => updateValue(platform, Number(event.target.value))}
+                            aria-label={`${PLATFORM_LABELS[platform] || platform} percent`}
                           />
-                        </div>
-                        <div className="flex items-center">
-                          <div className="flex h-9 w-full items-center justify-between rounded-xl bg-surface-2/80 px-3 text-sm text-white/80 ring-1 ring-white/10 transition focus-within:ring-2 focus-within:ring-brand/40">
-                            <input
-                              type="number"
-                              min={0}
-                              max={100}
-                              step={1}
-                              value={Number.isFinite(value) ? value : 0}
-                              onChange={(event) =>
-                                updateValue(platform, Number(event.target.value))
-                              }
-                              aria-label={`${PLATFORM_LABELS[platform] || platform} percent`}
-                              className="w-full bg-transparent text-right outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                            />
-                            <span className="text-xs text-white/50">%</span>
-                          </div>
-                        </div>
-                        <div className="flex items-center">
-                          <div
-                            className={cn(
-                              'flex h-9 w-full items-center gap-2 rounded-xl bg-surface-2/80 px-3 text-sm ring-1 ring-white/10 transition focus-within:ring-2 focus-within:ring-brand/40',
-                              manualCpl ? 'text-white/80' : 'text-white/40'
-                            )}
-                          >
-                            <span className="text-xs font-semibold uppercase text-white/50">
-                              {currency}
-                            </span>
-                            <input
-                              type="number"
-                              min={0}
-                              step={1}
-                              value={Number.isFinite(cplValue) ? cplValue : ''}
-                              onChange={(event) =>
-                                updateCpl(platform, event.target.value)
-                              }
-                              placeholder="Auto"
-                              aria-label={`${PLATFORM_LABELS[platform] || platform} CPL override`}
-                              className="w-full bg-transparent text-right outline-none placeholder:text-white/40 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none disabled:text-white/40"
-                              disabled={!manualCpl}
-                            />
-                          </div>
+                          <span>%</span>
                         </div>
                       </div>
-                    );
-                  })}
-                </div>
-
-                {!manualCpl && (
-                  <p className="text-[12px] text-white/50">
-                    CPL overrides follow model defaults until Manual CPL is enabled.
-                  </p>
-                )}
-
-                <div className="flex flex-wrap items-center gap-3">
-                  <div
-                    className={cn(
-                      'flex w-full flex-col gap-2 text-xs text-white/70 sm:w-auto',
-                      sum !== 100 && 'text-amber-300'
-                    )}
-                  >
-                    <span className="font-semibold">Sum: {sum}%</span>
-                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10 sm:w-40">
                       <div
                         className={cn(
-                          'h-full rounded-full bg-brand',
-                          sum !== 100 && 'bg-amber-300'
+                          'channels-slider__input channels-slider__input--currency',
+                          manualCpl ? 'is-active' : 'is-disabled'
                         )}
-                        style={{ width: `${Math.max(0, Math.min(100, sum))}%` }}
-                      />
+                      >
+                        <span>{currency}</span>
+                        {manualCpl ? (
+                          <input
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={Number.isFinite(cplValue) ? cplValue : ''}
+                            onChange={(event) => updateCpl(platform, event.target.value)}
+                            placeholder="Auto"
+                            aria-label={`${PLATFORM_LABELS[platform] || platform} CPL override`}
+                          />
+                        ) : (
+                          <span className="channels-slider__auto">Auto</span>
+                        )}
+                      </div>
                     </div>
+                  );
+                })}
+              </div>
+
+              {!manualCpl && (
+                <p className="channels-helper">
+                  CPL overrides follow model defaults until Manual CPL is enabled.
+                </p>
+              )}
+
+              <div className="channels-drawer__footer">
+                <div className={cn('channels-sum', sum !== 100 && 'is-warn')}>
+                  <span>Sum: {sum}%</span>
+                  <div className="channels-sum__bar">
+                    <div
+                      className="channels-sum__fill"
+                      style={{ width: `${Math.max(0, Math.min(100, sum))}%` }}
+                    />
                   </div>
-                  <div className="flex flex-wrap items-center gap-2 md:gap-3">
-                    <button type="button" className={pillButtonClass} onClick={equalize} disabled={!selectedCount}>
-                      Equal split
-                    </button>
-                    <button type="button" className={pillButtonClass} onClick={normalize} disabled={!selectedCount}>
-                      Normalize
-                    </button>
-                    <button type="button" className={pillButtonClass} onClick={clear} disabled={!selectedCount}>
-                      Clear
-                    </button>
-                  </div>
-                  <button
-                    type="button"
-                    className={cn(
-                      pillButtonClass,
-                      enforceMinEach && 'bg-brand/10 text-brand-100 ring-brand/30'
-                    )}
-                    onClick={() => onEnforceMinEachChange(!enforceMinEach)}
-                    aria-pressed={enforceMinEach}
-                  >
-                    <span className="relative flex h-3 w-3 items-center justify-center">
-                      <span
-                        className={cn(
-                          'h-2 w-2 rounded-full bg-brand transition-opacity',
-                          enforceMinEach ? 'opacity-100' : 'opacity-0'
-                        )}
-                      />
-                    </span>
-                    Min 10% each
+                </div>
+                <div className="channels-drawer__actions">
+                  <button type="button" onClick={equalize} disabled={!selectedCount}>
+                    Equal split
+                  </button>
+                  <button type="button" onClick={normalize} disabled={!selectedCount}>
+                    Normalize
+                  </button>
+                  <button type="button" onClick={clear} disabled={!selectedCount}>
+                    Clear
                   </button>
                 </div>
-
-                {minViolation && (
-                  <p className="text-[12px] text-rose-300" role="alert">
-                    Raise each channel to at least 10% when Min 10% each is on.
-                  </p>
-                )}
+                <label className="channels-min-toggle">
+                  <input
+                    type="checkbox"
+                    checked={enforceMinEach}
+                    onChange={(event) => onEnforceMinEachChange(event.target.checked)}
+                  />
+                  Min 10% each
+                </label>
               </div>
+
+              {minViolation && (
+                <p className="channels-error" role="alert">
+                  Raise each channel to at least 10% when Min 10% each is on.
+                </p>
+              )}
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/components/MediaPlannerCard.tsx
+++ b/src/components/MediaPlannerCard.tsx
@@ -4,12 +4,11 @@ import type { Goal, Market, Currency } from '../lib/assumptions';
 import { Card, microTitleClass } from './ui/Card';
 import { Tooltip } from './ui/Tooltip';
 
-const helperPillClass =
-  'inline-flex h-8 items-center rounded-full bg-surface-3/70 px-3 text-xs font-medium text-white/70 ring-1 ring-white/10';
-const fieldLabelClass = 'text-xs font-semibold uppercase tracking-[0.12em] text-white/60';
-const inputClass =
-  'h-10 w-full rounded-xl bg-surface-3/70 px-3 text-sm text-white/80 ring-1 ring-white/10 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40';
-const hintClass = 'text-xs text-white/50';
+const helperPillClass = 'media-card__pill';
+const objectiveButtonClass = 'media-card__objective';
+const fieldLabelClass = 'media-card__label';
+const inputClass = 'media-card__input';
+const hintClass = 'media-card__hint';
 
 const OBJECTIVES: { value: Goal; label: string }[] = [
   { value: 'LEADS', label: 'Leads' },
@@ -201,7 +200,7 @@ export default function MediaPlannerCard({
               <button
                 key={objective.value}
                 type="button"
-                className={`${helperPillClass} ${active ? 'bg-brand/10 text-brand-100 ring-brand/30' : ''}`}
+                className={objectiveButtonClass}
                 aria-pressed={active}
                 onClick={() => onGoalChange(objective.value)}
               >

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -13,7 +13,7 @@ export const Card = forwardRef<HTMLElement, CardProps>(function Card(
     <section
       ref={ref}
       className={cn(
-        'isolate space-y-3 rounded-2xl bg-surface-2 p-4 md:p-5 ring-1 ring-white/10 shadow-soft',
+        'planner-card space-y-3',
         className
       )}
       {...props}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -432,6 +432,98 @@ body.planner-in .appBg::after{opacity:.18}
   gap:16px;
 }
 
+/* Modern media planner inputs */
+.media-card__pill {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 14px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(12,18,28,0.72);
+  color:rgba(231,236,243,0.78);
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  box-shadow:0 12px 28px rgba(8,12,20,0.35);
+}
+
+.media-card__pill:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px rgba(107,112,255,0.35);
+}
+
+.media-card__input{
+  height:44px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(12,18,28,0.78);
+  color:#f4f7ff;
+  padding:0 14px;
+  font-size:14px;
+  font-weight:500;
+  letter-spacing:0.01em;
+  transition:border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.media-card__input::placeholder{
+  color:rgba(231,236,243,0.48);
+}
+
+.media-card__input:focus{
+  outline:none;
+  background:rgba(20,26,40,0.95);
+  border-color:rgba(107,112,255,0.55);
+  box-shadow:0 0 0 3px rgba(107,112,255,0.25);
+}
+
+.media-card__input option{
+  background:#060a11;
+  color:#f4f7ff;
+}
+
+.media-card__objective{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:8px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(12,18,28,0.72);
+  color:rgba(231,236,243,0.82);
+  font-size:13px;
+  font-weight:600;
+  letter-spacing:0.04em;
+  transition:all 0.18s ease;
+  cursor:pointer;
+}
+
+.media-card__objective:hover{
+  transform:translateY(-1px);
+  border-color:rgba(107,112,255,0.45);
+}
+
+.media-card__objective[aria-pressed="true"]{
+  background:linear-gradient(135deg, rgba(107,112,255,0.35), rgba(62,139,255,0.45));
+  color:#fff;
+  border-color:rgba(107,112,255,0.55);
+  box-shadow:0 10px 28px rgba(8,12,20,0.45);
+}
+
+.media-card__label{
+  font-size:12px;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:0.14em;
+  color:rgba(231,236,243,0.55);
+}
+
+.media-card__hint{
+  font-size:12px;
+  color:rgba(231,236,243,0.6);
+}
+
 /* Channels & Splits card */
 .channels-card{
   background:linear-gradient(180deg, rgba(22,30,45,0.92), rgba(9,13,22,0.94));
@@ -482,6 +574,16 @@ body.planner-in .appBg::after{opacity:.18}
 .channels-slider__input input[type="number"]::-webkit-inner-spin-button{appearance:none;margin:0;}
 .channels-slider__input input[type="number"]{-moz-appearance:textfield;appearance:textfield;}
 .channels-slider__input span{font-size:12px;color:rgba(231,236,243,0.7);padding-right:8px;}
+.channels-slider__input--currency{min-width:150px;padding:0 12px;gap:10px;justify-content:space-between;}
+.channels-slider__input--currency span:first-child{font-size:11px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:rgba(231,236,243,0.62);padding:0;}
+.channels-slider__input--currency span:last-child{padding-right:0;}
+.channels-slider__input--currency input{flex:1;min-width:0;text-align:right;}
+.channels-slider__auto{margin-left:auto;font-size:13px;font-weight:600;color:rgba(231,236,243,0.65);}
+.channels-slider__input.is-active{box-shadow:inset 0 0 0 1px rgba(127,85,224,0.28);}
+.channels-slider__input.is-disabled{opacity:0.45;}
+.channels-slider__input.is-disabled input{color:rgba(231,236,243,0.45);}
+.channels-slider__input.is-disabled span{color:rgba(231,236,243,0.45);}
+.channels-slider__input.is-disabled input::placeholder{color:rgba(231,236,243,0.3);}
 .channels-drawer__footer{display:flex;align-items:center;gap:16px;flex-wrap:wrap;justify-content:space-between;}
 .channels-sum{display:flex;flex-direction:column;gap:6px;font-size:13px;color:rgba(231,236,243,0.78);}
 .channels-sum.is-warn{color:#ffb96a;}
@@ -871,6 +973,8 @@ body.planner-in .appBg::after{opacity:.18}
 .kpi-status__text{display:flex;flex-direction:column;gap:6px;color:rgba(231,236,243,0.82)}
 .kpi-status__title{font-size:15px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#f1f5ff}
 .kpi-status__sub{font-size:12px;color:rgba(231,236,243,0.68);letter-spacing:.02em;line-height:1.4}
+.kpi-status__control{display:flex;align-items:center;gap:12px;flex-shrink:0}
+.kpi-status__state{font-size:11px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:rgba(231,236,243,0.62)}
 .kpi-status .switch{flex-shrink:0}
 
 .kpi-list{

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,9 +18,9 @@ export default {
         border: '#333333',
         divider: '#2b2b2b',
         surface: {
-          1: 'rgba(10, 16, 29, 0.78)',
-          2: 'rgba(12, 18, 28, 0.92)',
-          3: 'rgba(22, 30, 45, 0.78)',
+          1: '#0A101DC7',
+          2: '#0C121CEB',
+          3: '#161E2DC7',
         },
         brand: {
           DEFAULT: '#6B70FF',


### PR DESCRIPTION
## Summary
- restyle the media planner card to use dark-themed form controls and helper pills
- add CSS tokens for the planner form and reuse the shared planner-card surface
- align Tailwind surface colors with hex values so surface utilities match the gradient palette
- rebuild the KPI summary card with planner tokens, a themed auto-CPL switch, and styled metric pills
- redesign the channels & splits drawer to match planner styling and clarify manual CPL overrides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cf9ffaf7648321852bffad83444f87